### PR TITLE
🔧 config: dev, prod 환경별 Spring 설정 파일 분리 적용

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    show-sql: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    show-sql: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,6 @@
+spring:
+  profiles:
+    active: dev # 기본 실행 환경
+
 server:
   port: 8080
-
-spring:
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
-
-logging:
-  level:
-    root: info
-    org.springframework.web: debug


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- 개발, 운영 환경 파일을 분리하여 관리하도록 설정

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- 기존 application.yml 파일을 dev, prod, main으로 나누었습니다.

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. IntelliJ Run/Debug Configurations에서 직접 환경 변수 넣기
2. 오른쪽 상단 실행 버튼 옆의 드롭다운 클릭 -> Edit Configurations 클릭
3. Environment variables 칸 클릭
4. DB_URL=<URL>;DB_USERNAME=<username>;DB_PASSWORD=<password> 입력
5. KickyApplication.java 실행

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함
- [x] 필요 시 문서 업데이트 완료
- [x] 관련 이슈에 연결함

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #2
