### PR TITLE
📦 chore: husky 전용 setup 스크립트로 변경

### DIFF
--- a/dev-scripts/setup-dev.sh
+++ b/dev-scripts/setup-dev.sh
@@ -1,18 +1,36 @@
 #!/bin/bash
 set -e
 
-pip install pre-commit
+echo "[1/5] Git 저장소 여부 확인"
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  echo "Git 저장소 내부에서 실행해 주세요."; exit 1;
+}
 
-# bash 환경 재로딩 (윈도우 Git Bash / 맥 bash 공통)
-if [ -f ~/.bashrc ]; then
-    source ~/.bashrc
+echo "[2/5] Git hooks 경로(.husky) 설정 확인"
+current_hooks_path="$(git config --get core.hooksPath || true)"
+if [ "$current_hooks_path" != ".husky" ]; then
+  git config core.hooksPath .husky
+  echo "core.hooksPath를 .husky로 설정했습니다."
+else
+  echo "core.hooksPath가 이미 .husky로 설정되어 있습니다."
 fi
 
-# 맥 zsh 환경 대응
-if [ -f ~/.zshrc ]; then
-    source ~/.zshrc
+echo "[3/5] Node 모듈 설치 (npm ci가 가능하면 우선 사용)"
+if [ -f package-lock.json ]; then
+  npm ci || npm install
+else
+  npm install
 fi
 
-pre-commit install
-pre-commit install --hook-type commit-msg
-npm install
+echo "[4/5] Husky 설치 실행 (package.json의 prepare 스크립트)"
+npm run -s prepare || true
+
+echo "[5/5] 기존 훅 파일 권한 보정"
+if [ -f .husky/pre-commit ]; then
+  chmod +x .husky/pre-commit || true
+fi
+if [ -f .husky/commit-msg ]; then
+  chmod +x .husky/commit-msg || true
+fi
+
+echo "완료: Husky 전용 설정이 적용되었습니다. 기존 훅 파일은 그대로 유지되었습니다."


### PR DESCRIPTION
## 📌 PR 개요

* Python 기반 pre-commit 설정을 제거하고 Husky 전용 setup 스크립트로 변경

## 🔍 변경 사항

* Python pre-commit 설치 및 훅 설치 로직 제거
* Git hooks 경로를 `.husky`로 고정 설정
* `npm ci` 우선 실행 후 `prepare` 스크립트를 통한 Husky 설치 적용
* 기존 `.husky/pre-commit`, `.husky/commit-msg` 파일은 유지하고 실행 권한만 보정

## 🧪 테스트 방법

1. 기존 훅 파일이 있는 상태에서 `setup-dev.sh` 실행
2. `.husky` 폴더 및 기존 훅 파일 유지 여부 확인
3. 커밋 시 Spotless/Checkstyle 및 Commitlint 정상 동작 확인

## ✅ 체크리스트

* [x] 코드가 정상적으로 동작함
* [x] 기존 기능에 문제가 없음
* [x] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함
* [ ] 필요 시 문서 업데이트 완료
* [ ] 관련 이슈에 연결함

## 📎 참고 이슈

Ref: #
