### PR TITLE
match participants entity repo

### DIFF
--- a/src/main/java/com/nextcloudlab/kickytime/common/entity/BaseEntity.java
+++ b/src/main/java/com/nextcloudlab/kickytime/common/entity/BaseEntity.java
@@ -1,14 +1,15 @@
 package com.nextcloudlab.kickytime.common.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
-import lombok.Getter;
+import java.time.LocalDateTime;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 
 @Getter
 @MappedSuperclass // 상속받는 엔티티에 매핑 정보 전달

--- a/src/main/java/com/nextcloudlab/kickytime/common/entity/BaseEntity.java
+++ b/src/main/java/com/nextcloudlab/kickytime/common/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.nextcloudlab.kickytime.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass // 상속받는 엔티티에 매핑 정보 전달
+@EntityListeners(AuditingEntityListener.class) // JPA Auditing 활성화
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/nextcloudlab/kickytime/match/entity/Match.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/entity/Match.java
@@ -2,8 +2,7 @@ package com.nextcloudlab.kickytime.match.entity;
 
 import java.time.LocalDateTime;
 
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
+import com.nextcloudlab.kickytime.common.entity.BaseEntity;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.nextcloudlab.kickytime.user.entity.User;
@@ -22,7 +21,7 @@ import lombok.Setter;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "matches")
-public class Match {
+public class Match extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -44,14 +43,6 @@ public class Match {
     @Max(value = 22, message = "최대 22명까지 가능합니다.")
     @Column(nullable = false)
     private Integer maxPlayers;
-
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/nextcloudlab/kickytime/match/entity/Match.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/entity/Match.java
@@ -2,9 +2,9 @@ package com.nextcloudlab.kickytime.match.entity;
 
 import java.time.LocalDateTime;
 
-import com.nextcloudlab.kickytime.common.entity.BaseEntity;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import com.nextcloudlab.kickytime.common.entity.BaseEntity;
 import com.nextcloudlab.kickytime.user.entity.User;
 
 import jakarta.persistence.*;

--- a/src/main/java/com/nextcloudlab/kickytime/match/entity/MatchParticipant.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/entity/MatchParticipant.java
@@ -1,16 +1,17 @@
 package com.nextcloudlab.kickytime.match.entity;
 
 import com.nextcloudlab.kickytime.user.entity.User;
+
 import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "match_participants",
+@Table(
+        name = "match_participants",
         uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "uk_match_user",
-                        columnNames = {"match_id", "user_id"}
-                )
+            @UniqueConstraint(
+                    name = "uk_match_user",
+                    columnNames = {"match_id", "user_id"})
         })
 @Getter
 @Setter
@@ -38,5 +39,4 @@ public class MatchParticipant {
     protected void onCreate() {
         joinedAt = java.time.LocalDateTime.now();
     }
-
 }

--- a/src/main/java/com/nextcloudlab/kickytime/match/entity/MatchParticipant.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/entity/MatchParticipant.java
@@ -3,14 +3,14 @@ package com.nextcloudlab.kickytime.match.entity;
 import com.nextcloudlab.kickytime.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "match_participants",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"match_id", "user_id"})
+                @UniqueConstraint(
+                        name = "uk_match_user",
+                        columnNames = {"match_id", "user_id"}
+                )
         })
 @Getter
 @Setter

--- a/src/main/java/com/nextcloudlab/kickytime/match/entity/MatchParticipant.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/entity/MatchParticipant.java
@@ -1,0 +1,42 @@
+package com.nextcloudlab.kickytime.match.entity;
+
+import com.nextcloudlab.kickytime.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "match_participants",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"match_id", "user_id"})
+        })
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MatchParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "match_id", nullable = false)
+    private Match match;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private java.time.LocalDateTime joinedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        joinedAt = java.time.LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/nextcloudlab/kickytime/match/repository/MatchParticipantRepository.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/repository/MatchParticipantRepository.java
@@ -1,8 +1,7 @@
 package com.nextcloudlab.kickytime.match.repository;
 
-import com.nextcloudlab.kickytime.match.entity.MatchParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MatchParticipantRepository extends JpaRepository<MatchParticipant, Long> {
+import com.nextcloudlab.kickytime.match.entity.MatchParticipant;
 
-}
+public interface MatchParticipantRepository extends JpaRepository<MatchParticipant, Long> {}

--- a/src/main/java/com/nextcloudlab/kickytime/match/repository/MatchParticipantRepository.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/repository/MatchParticipantRepository.java
@@ -1,0 +1,8 @@
+package com.nextcloudlab.kickytime.match.repository;
+
+import com.nextcloudlab.kickytime.match.entity.MatchParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchParticipantRepository extends JpaRepository<MatchParticipant, Long> {
+
+}

--- a/src/main/java/com/nextcloudlab/kickytime/user/entity/User.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/entity/User.java
@@ -54,7 +54,6 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private RankEnum rank;
 
-
     @PrePersist
     public void prePersist() {
         if (this.role == null) this.role = RoleEnum.USER;

--- a/src/main/java/com/nextcloudlab/kickytime/user/entity/User.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/entity/User.java
@@ -1,6 +1,6 @@
 package com.nextcloudlab.kickytime.user.entity;
 
-import org.springframework.data.annotation.CreatedDate;
+import com.nextcloudlab.kickytime.common.entity.BaseEntity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
@@ -15,7 +15,7 @@ import lombok.*;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -54,15 +54,11 @@ public class User {
     @Enumerated(EnumType.STRING)
     private RankEnum rank;
 
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private java.time.LocalDateTime createdAt;
 
     @PrePersist
     public void prePersist() {
         if (this.role == null) this.role = RoleEnum.USER;
         if (this.rank == null) this.rank = RankEnum.BEGINNER;
         if (this.imageUrl == null) this.imageUrl = "/images/default-profile.png";
-        if (this.createdAt == null) this.createdAt = java.time.LocalDateTime.now();
     }
 }


### PR DESCRIPTION
## 📌 PR 개요
- 매치 참여 관리 기능을 위해 `MatchParticipant` 엔티티 및 레포지토리 생성
- 공통 생성/수정일시 관리용 `BaseEntity` 추가

## 🔍 변경 사항
- `BaseEntity` 생성 및 `Match`, `User`에 적용
- `MatchParticipant` 엔티티 추가 (매치-유저 참여 관계, 중복 참여 방지 제약 포함)
- `MatchParticipantRepository` 생성 (매치별/유저별 참여 조회, 중복 체크 메서드 포함)
- DB 스키마에 맞춘 FK, Unique 제약 설정

## 🧪 테스트 방법
1. 로컬 서버 실행 후 매치 및 유저 생성
2. 동일 유저가 동일 매치에 중복 등록되지 않는지 확인

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함
- [x] 필요 시 문서 업데이트 완료
- [x] 관련 이슈에 연결함

## 📎 참고 이슈
Ref: #11
