### PR TITLE
✨ feat(match): 관리자 매치 삭제 API 구현

### DIFF
--- a/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
@@ -1,14 +1,11 @@
-package com.example.yourproject.controller;
+package com.nextcloudlab.kickytime.controller;
 
+import com.nextcloudlab.kickytime.service.MatchingService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import com.example.yourproject.service.MatchingService;
-
-import lombok.RequiredArgsConstructor;
-
-// 관리자 전용 매치 삭제 API 컨트롤러
 @RestController
 @RequestMapping("/api/matches")
 @RequiredArgsConstructor
@@ -20,6 +17,6 @@ public class MatchingAdminController {
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> deleteMatch(@PathVariable Long matchId) {
         matchingService.deleteMatchById(matchId);
-        return ResponseEntity.noContent().build();  // 204 No Content
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
@@ -1,12 +1,12 @@
 package com.nextcloudlab.kickytime.controller;
 
-import com.nextcloudlab.kickytime.service.MatchingService;
-
-import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import com.nextcloudlab.kickytime.service.MatchingService;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/matches")

--- a/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
@@ -1,15 +1,12 @@
 package com.nextcloudlab.kickytime.controller;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.nextcloudlab.kickytime.service.MatchingService;
 
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/matches")

--- a/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
@@ -1,6 +1,5 @@
 package com.nextcloudlab.kickytime.controller;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -9,6 +8,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nextcloudlab.kickytime.service.MatchingService;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/matches")

--- a/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
@@ -1,0 +1,25 @@
+package com.example.yourproject.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import com.example.yourproject.service.MatchingService;
+
+import lombok.RequiredArgsConstructor;
+
+/ * 관리자 전용 매치 삭제 API 컨트롤러
+@RestController
+@RequestMapping("/api/matches")
+@RequiredArgsConstructor
+public class MatchingAdminController {
+
+    private final MatchingService matchingService;
+
+    @DeleteMapping("/{matchId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> deleteMatch(@PathVariable Long matchId) {
+        matchingService.deleteMatchById(matchId);
+        return ResponseEntity.noContent().build();  // 204 No Content
+    }
+}

--- a/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
@@ -8,7 +8,7 @@ import com.example.yourproject.service.MatchingService;
 
 import lombok.RequiredArgsConstructor;
 
-/ * 관리자 전용 매치 삭제 API 컨트롤러
+// 관리자 전용 매치 삭제 API 컨트롤러
 @RestController
 @RequestMapping("/api/matches")
 @RequiredArgsConstructor

--- a/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
@@ -1,10 +1,12 @@
 package com.nextcloudlab.kickytime.controller;
 
-import com.nextcloudlab.kickytime.service.MatchingService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import com.nextcloudlab.kickytime.service.MatchingService;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/matches")

--- a/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/controller/MatchingAdminController.java
@@ -1,12 +1,14 @@
 package com.nextcloudlab.kickytime.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.nextcloudlab.kickytime.service.MatchingService;
-
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/matches")

--- a/src/main/java/com/nextcloudlab/kickytime/service/MatchingService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/service/MatchingService.java
@@ -2,11 +2,8 @@ package com.nextcloudlab.kickytime.service;
 
 import com.nextcloudlab.kickytime.match.entity.Match;
 import com.nextcloudlab.kickytime.match.repository.MatchRepository;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.stereotype.Service;
-
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/nextcloudlab/kickytime/service/MatchingService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/service/MatchingService.java
@@ -1,8 +1,8 @@
 package com.nextcloudlab.kickytime.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import com.nextcloudlab.kickytime.match.entity.Match;
 import com.nextcloudlab.kickytime.match.repository.MatchRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -13,11 +13,14 @@ public class MatchingService {
 
     private final MatchRepository matchRepository;
 
+    @Transactional
     public void deleteMatchById(Long matchId) {
-        Match match =
-                matchRepository
-                        .findById(matchId)
-                        .orElseThrow(() -> new IllegalArgumentException("해당 매치를 찾을 수 없습니다."));
-        matchRepository.delete(match);
+        // match가 존재하는지 확인 (Optional 사용 가능)
+        if (!matchRepository.existsById(matchId)) {
+            throw new IllegalArgumentException("해당 매치를 찾을 수 없습니다.");
+        }
+
+        // match 삭제 (cascade 설정 시 연관된 match_participants도 삭제됨)
+        matchRepository.deleteById(matchId);
     }
 }

--- a/src/main/java/com/nextcloudlab/kickytime/service/MatchingService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/service/MatchingService.java
@@ -1,0 +1,24 @@
+package com.example.yourproject.service;
+
+import com.example.yourproject.domain.Matching;
+import com.example.yourproject.repository.MatchingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MatchingService {
+
+    private final MatchingRepository matchingRepository;
+
+    /**
+     * 주어진 matchId에 해당하는 매칭을 삭제합니다.
+     * @param matchId 삭제할 매칭 ID
+     * @throws ResourceNotFoundException 매칭을 찾지 못한 경우
+     */
+    public void deleteMatchById(Long matchId) {
+        Matching match = matchingRepository.findById(matchId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 매칭을 찾을 수 없습니다."));
+        matchingRepository.delete(match);
+    }
+}

--- a/src/main/java/com/nextcloudlab/kickytime/service/MatchingService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/service/MatchingService.java
@@ -1,9 +1,11 @@
 package com.nextcloudlab.kickytime.service;
 
+import org.springframework.stereotype.Service;
+
 import com.nextcloudlab.kickytime.match.entity.Match;
 import com.nextcloudlab.kickytime.match.repository.MatchRepository;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -12,8 +14,10 @@ public class MatchingService {
     private final MatchRepository matchRepository;
 
     public void deleteMatchById(Long matchId) {
-        Match match = matchRepository.findById(matchId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 매치를 찾을 수 없습니다."));
+        Match match =
+                matchRepository
+                        .findById(matchId)
+                        .orElseThrow(() -> new IllegalArgumentException("해당 매치를 찾을 수 없습니다."));
         matchRepository.delete(match);
     }
 }

--- a/src/main/java/com/nextcloudlab/kickytime/service/MatchingService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/service/MatchingService.java
@@ -1,7 +1,7 @@
-package com.example.yourproject.service;
+package com.nextcloudlab.kickytime.service;
 
-import com.example.yourproject.domain.Matching;
-import com.example.yourproject.repository.MatchingRepository;
+import com.nextcloudlab.kickytime.match.entity.Match;
+import com.nextcloudlab.kickytime.match.repository.MatchRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,16 +9,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MatchingService {
 
-    private final MatchingRepository matchingRepository;
+    private final MatchRepository matchRepository;
 
-    /**
-     * 주어진 matchId에 해당하는 매칭을 삭제합니다.
-     * @param matchId 삭제할 매칭 ID
-     * @throws ResourceNotFoundException 매칭을 찾지 못한 경우
-     */
     public void deleteMatchById(Long matchId) {
-        Matching match = matchingRepository.findById(matchId)
-                .orElseThrow(() -> new ResourceNotFoundException("해당 매칭을 찾을 수 없습니다."));
-        matchingRepository.delete(match);
+        Match match = matchRepository.findById(matchId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 매치를 찾을 수 없습니다."));
+        matchRepository.delete(match);
     }
 }

--- a/src/main/java/com/nextcloudlab/kickytime/service/MatchingService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/service/MatchingService.java
@@ -2,8 +2,11 @@ package com.nextcloudlab.kickytime.service;
 
 import com.nextcloudlab.kickytime.match.entity.Match;
 import com.nextcloudlab.kickytime.match.repository.MatchRepository;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
+
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- 관리자 권한으로 매치 삭제 API를 구현했습니다.

- 특정 matchId에 해당하는 매치를 삭제할 수 있습니다.
## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- MatchingAdminController에 DELETE /api/matches/{matchId} API 추가
- MatchingService에 매치 삭제 로직 구현 및 호출
## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. 관리자 권한으로 로그인하여 삭제 API 호출
2. 삭제하려는 matchId를 포함한 DELETE 요청 전송
3. HTTP 204 No Content 응답 확인 및 데이터베이스에서 삭제 여부 검증
## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함
- [x] 필요 시 문서 업데이트 완료
- [x] 관련 이슈에 연결함

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #31 
