### PR TITLE
Feature/27 user sign in up

### DIFF
--- a/src/main/java/com/nextcloudlab/kickytime/config/SecurityConfig.java
+++ b/src/main/java/com/nextcloudlab/kickytime/config/SecurityConfig.java
@@ -1,14 +1,21 @@
 package com.nextcloudlab.kickytime.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.*;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class SecurityConfig {
+    @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
+    private String issuerUri;
+
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
@@ -26,9 +33,20 @@ public class SecurityConfig {
                                         .authenticated()
                                         .anyRequest()
                                         .permitAll())
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .oauth2ResourceServer(
+                        oauth2 -> oauth2.jwt(jwt -> jwt.decoder(accessTokenDecoder())))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable);
         return http.build();
+    }
+
+    @Bean
+    JwtDecoder accessTokenDecoder() {
+        NimbusJwtDecoder decoder = JwtDecoders.fromIssuerLocation(issuerUri);
+        OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuerUri);
+        OAuth2TokenValidator<Jwt> tokenUserIsAccess = new TokenUseValidator("access");
+        decoder.setJwtValidator(
+                new DelegatingOAuth2TokenValidator<>(withIssuer, tokenUserIsAccess));
+        return decoder;
     }
 }

--- a/src/main/java/com/nextcloudlab/kickytime/config/TokenUseValidator.java
+++ b/src/main/java/com/nextcloudlab/kickytime/config/TokenUseValidator.java
@@ -1,0 +1,28 @@
+package com.nextcloudlab.kickytime.config;
+
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class TokenUseValidator implements OAuth2TokenValidator<Jwt> {
+    private final String expected;
+
+    public TokenUseValidator(String expected) {
+        this.expected = expected;
+    }
+
+    @Override
+    public OAuth2TokenValidatorResult validate(Jwt token) {
+        String tokenUse = token.getClaimAsString("token_use");
+        if (expected.equals(tokenUse)) {
+            return OAuth2TokenValidatorResult.success();
+        }
+        OAuth2Error error =
+                new OAuth2Error(
+                        "invalid_token",
+                        "Invalid token_use: expected '" + expected + "', got '" + tokenUse + "'",
+                        null);
+        return OAuth2TokenValidatorResult.failure(error);
+    }
+}

--- a/src/main/java/com/nextcloudlab/kickytime/util/CognitoUserInfoClient.java
+++ b/src/main/java/com/nextcloudlab/kickytime/util/CognitoUserInfoClient.java
@@ -1,0 +1,28 @@
+package com.nextcloudlab.kickytime.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class CognitoUserInfoClient {
+    private final RestClient restClient;
+    private final String userInfoUri;
+
+    public CognitoUserInfoClient(@Value("${app.cognito.user-info-uri}") String userInfoUri) {
+        this.restClient = RestClient.builder().build();
+        this.userInfoUri = userInfoUri;
+    }
+
+    public UserInfo fetch(String accessToken) {
+        return restClient
+                .get()
+                .uri(userInfoUri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .body(UserInfo.class);
+    }
+
+    public record UserInfo(String email, String nickname) {}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,14 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: https://cognito-idp.ap-northeast-2.amazonaws.com/ap-northeast-2_xI18xw5er/.well-known/jwks.json
+          issuer-uri: https://cognito-idp.ap-northeast-2.amazonaws.com/ap-northeast-2_xI18xw5er
+
+app:
+  cognito:
+    region: ap-northeast-2
+    user-pool-id: ap-northeast-2_xI18xw5er
+    client-id: 6l5ovdmof4vc5r2socegk41gt4
+    user-info-uri: https://ap-northeast-2xi18xw5er.auth.ap-northeast-2.amazoncognito.com/oauth2/userInfo
 
 server:
   port: 8080


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- Cognito Access Token 기반 인증 후, Cognito UserInfo로 `email`, `nickname` 조회하여 회원 조회/생성
- /api/users/me 엔드포인트를 GET에서 POST로 변경

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- `SecurityConfig`
> - Access 토큰 전용 `JwtDecoder` 구성(issuer 검증 + `TokenUseValidator("access")`)
- `config`
> - `TokenUseValidator` 추가: `token_use`가 `"access"`인지 검증
- `util` 추가
> - `CognitoUserInfoClient` 추가: `/oauth2/userInfo` 호출로 `email`, `nickname` 조회

- `UserController`
> - `GET /api/users/me` → `POST /api/users/me`로 변경
> - 헤더의 `Authorization: Bearer <ACCESS_TOKEN>`만으로 사용자 정보 조회

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1.Cognito Hosted UI 로그인으로 **Access Token 발급**
2.Postman에서 아래 요청 실행
3.POST http://localhost:8080/api/users/me
4.응답으로 사용자 정보 JSON이 반환되는지 확인

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작함
- [ ] 기존 기능에 문제가 없음
- [ ] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #27 
