### PR TITLE
Feature/41 match delete api junit test

### DIFF
--- a/src/main/java/com/nextcloudlab/kickytime/match/controller/MatchController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/controller/MatchController.java
@@ -65,5 +65,4 @@ public class MatchController {
         matchService.deleteMatchById(matchId);
         return ResponseEntity.noContent().build();
     }
-
 }

--- a/src/main/java/com/nextcloudlab/kickytime/match/controller/MatchController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/controller/MatchController.java
@@ -59,4 +59,11 @@ public class MatchController {
         MyMatchesResponse response = matchParticipantService.getMyParticipant(cognitoSub);
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/{matchId}")
+    public ResponseEntity<Void> deleteMatch(@PathVariable Long matchId) {
+        matchService.deleteMatchById(matchId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/nextcloudlab/kickytime/match/service/MatchService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/service/MatchService.java
@@ -131,5 +131,4 @@ public class MatchService {
 
         matchRepository.deleteById(matchId);
     }
-
 }

--- a/src/main/java/com/nextcloudlab/kickytime/match/service/MatchService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/service/MatchService.java
@@ -122,4 +122,14 @@ public class MatchService {
             match.setMatchStatus(MatchStatus.OPEN);
         }
     }
+
+    // 매칭 삭제 기능
+    public void deleteMatchById(Long matchId) {
+        if (!matchRepository.existsById(matchId)) {
+            throw new IllegalArgumentException("해당 매치를 찾을 수 없습니다.");
+        }
+
+        matchRepository.deleteById(matchId);
+    }
+
 }

--- a/src/test/java/com/nextcloudlab/kickytime/match/service/MatchServiceTest.java
+++ b/src/test/java/com/nextcloudlab/kickytime/match/service/MatchServiceTest.java
@@ -247,4 +247,36 @@ class MatchServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("참가 신청 내역을 찾을 수 없습니다.");
     }
+
+    @Test
+    @DisplayName("경기 삭제 - 성공")
+    void deleteMatchByIdSuccess() {
+        // given
+        Long matchId = 1L;
+        given(matchRepository.existsById(matchId)).willReturn(true);
+        doNothing().when(matchRepository).deleteById(matchId);
+
+        // when
+        assertDoesNotThrow(() -> matchService.deleteMatchById(matchId));
+
+        // then
+        verify(matchRepository).existsById(matchId);
+        verify(matchRepository).deleteById(matchId);
+    }
+
+    @Test
+    @DisplayName("경기 삭제 - 경기 없음 예외")
+    void deleteMatchByIdNotFound() {
+        // given
+        Long matchId = 1L;
+        given(matchRepository.existsById(matchId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> matchService.deleteMatchById(matchId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당 매치를 찾을 수 없습니다.");
+
+        verify(matchRepository).existsById(matchId);
+        verify(matchRepository, never()).deleteById(anyLong());
+    }
 }


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- 관리자 권한을 가진 사용자가 특정 매칭을 삭제할 수 있는 API를 추가했습니다.
- 매칭 삭제 시 해당 매칭이 존재하지 않으면 예외를 발생시켜 안전한 처리를 구현했습니다.

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- MatchService에 매칭 삭제 기능 추가 (deleteMatchById 메서드)
- MatchingAdminController에 매칭 삭제 API 엔드포인트 추가 (DELETE /api/matches/{matchId})
- 매칭 삭제 관련 테스트 코드 작성 (성공 및 실패 케이스)
- 패키지 구조 개선을 위해 컨트롤러 파일 일부 이동 및 리팩토링

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1.관리자 권한으로 DELETE 요청을 /api/matches/{matchId} 로 전송
2. 정상적으로 매칭이 삭제되고 HTTP 204 No Content 응답 확인
3. 존재하지 않는 매칭 ID로 삭제 시 예외 발생 및 적절한 에러 메시지 확인

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함
- [x] 필요 시 문서 업데이트 완료
- [x] 관련 이슈에 연결함

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #41 
