### PR TITLE
Feature/51 email verified add

### DIFF
--- a/src/main/java/com/nextcloudlab/kickytime/user/controller/UserController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/controller/UserController.java
@@ -22,11 +22,13 @@ public class UserController {
     }
 
     @PostMapping("/signin-up")
-    public User getMyInfo(@AuthenticationPrincipal Jwt accessToken) {
+    public User signInUp(@AuthenticationPrincipal Jwt accessToken) {
         String cognitoSub = accessToken.getClaimAsString("sub");
         var info = userInfoClient.fetch(accessToken.getTokenValue());
 
-        return userService.findOrCreateUser(cognitoSub, info.email(), info.nickname());
+        boolean emailVerified = Boolean.TRUE.equals(info.emailVerified());
+
+        return userService.findOrCreateUser(cognitoSub, info.email(), info.nickname(), emailVerified);
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/nextcloudlab/kickytime/user/controller/UserController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/controller/UserController.java
@@ -28,7 +28,8 @@ public class UserController {
 
         boolean emailVerified = Boolean.TRUE.equals(info.emailVerified());
 
-        return userService.findOrCreateUser(cognitoSub, info.email(), info.nickname(), emailVerified);
+        return userService.findOrCreateUser(
+                cognitoSub, info.email(), info.nickname(), emailVerified);
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/nextcloudlab/kickytime/user/dto/UserDto.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/dto/UserDto.java
@@ -7,6 +7,7 @@ import com.nextcloudlab.kickytime.user.entity.User;
 public record UserDto(
         Long id,
         String email,
+        Boolean email_verified,
         String nickname,
         String imageUrl,
         String role,
@@ -16,6 +17,7 @@ public record UserDto(
         return new UserDto(
                 user.getId(),
                 user.getEmail(),
+                user.isEmailVerified(),
                 user.getNickname(),
                 user.getImageUrl(),
                 user.getRole().name(),

--- a/src/main/java/com/nextcloudlab/kickytime/user/service/UserService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.nextcloudlab.kickytime.user.service;
 
 import java.util.Optional;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -13,27 +14,30 @@ import com.nextcloudlab.kickytime.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
 
-    public UserService(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
-
     @Transactional
-    public User findOrCreateUser(String cognitoSub, String email, String nickname) {
-        Optional<User> existingUser = userRepository.findByCognitoSub(cognitoSub);
-
-        if (existingUser.isPresent()) {
-            return existingUser.get();
-        } else {
-            User newUser = new User();
-            newUser.setCognitoSub(cognitoSub);
-            newUser.setEmail(email);
-            newUser.setNickname(nickname);
-            return userRepository.save(newUser);
-        }
+    public User findOrCreateUser(String cognitoSub, String email, String nickname, boolean emailVerified) {
+        return userRepository.findByCognitoSub(cognitoSub)
+                .map(user -> {
+                    // 변경 감지만 기대, save() 호출 X
+                    if (email != null && !email.equals(user.getEmail())) user.setEmail(email);
+                    if (nickname != null && !nickname.equals(user.getNickname())) user.setNickname(nickname);
+                    if (emailVerified && !user.isEmailVerified()) user.setEmailVerified(true);
+                    return user; // ← 기존 엔티티 그대로 반환
+                })
+                .orElseGet(() -> {
+                    // 신규 생성일 때만 save()
+                    User newUser = new User();
+                    newUser.setCognitoSub(cognitoSub);
+                    newUser.setEmail(email);
+                    newUser.setNickname(nickname);
+                    newUser.setEmailVerified(emailVerified);
+                    return userRepository.save(newUser);
+                });
     }
 
     @Transactional

--- a/src/main/java/com/nextcloudlab/kickytime/user/service/UserService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/service/UserService.java
@@ -1,8 +1,5 @@
 package com.nextcloudlab.kickytime.user.service;
 
-import java.util.Optional;
-
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -12,6 +9,7 @@ import com.nextcloudlab.kickytime.user.entity.User;
 import com.nextcloudlab.kickytime.user.repository.UserRepository;
 
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -20,24 +18,31 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Transactional
-    public User findOrCreateUser(String cognitoSub, String email, String nickname, boolean emailVerified) {
-        return userRepository.findByCognitoSub(cognitoSub)
-                .map(user -> {
-                    // 변경 감지만 기대, save() 호출 X
-                    if (email != null && !email.equals(user.getEmail())) user.setEmail(email);
-                    if (nickname != null && !nickname.equals(user.getNickname())) user.setNickname(nickname);
-                    if (emailVerified && !user.isEmailVerified()) user.setEmailVerified(true);
-                    return user; // ← 기존 엔티티 그대로 반환
-                })
-                .orElseGet(() -> {
-                    // 신규 생성일 때만 save()
-                    User newUser = new User();
-                    newUser.setCognitoSub(cognitoSub);
-                    newUser.setEmail(email);
-                    newUser.setNickname(nickname);
-                    newUser.setEmailVerified(emailVerified);
-                    return userRepository.save(newUser);
-                });
+    public User findOrCreateUser(
+            String cognitoSub, String email, String nickname, boolean emailVerified) {
+        return userRepository
+                .findByCognitoSub(cognitoSub)
+                .map(
+                        user -> {
+                            // 변경 감지만 기대, save() 호출 X
+                            if (email != null && !email.equals(user.getEmail()))
+                                user.setEmail(email);
+                            if (nickname != null && !nickname.equals(user.getNickname()))
+                                user.setNickname(nickname);
+                            if (emailVerified && !user.isEmailVerified())
+                                user.setEmailVerified(true);
+                            return user; // ← 기존 엔티티 그대로 반환
+                        })
+                .orElseGet(
+                        () -> {
+                            // 신규 생성일 때만 save()
+                            User newUser = new User();
+                            newUser.setCognitoSub(cognitoSub);
+                            newUser.setEmail(email);
+                            newUser.setNickname(nickname);
+                            newUser.setEmailVerified(emailVerified);
+                            return userRepository.save(newUser);
+                        });
     }
 
     @Transactional

--- a/src/main/java/com/nextcloudlab/kickytime/util/CognitoUserInfoClient.java
+++ b/src/main/java/com/nextcloudlab/kickytime/util/CognitoUserInfoClient.java
@@ -1,10 +1,11 @@
 package com.nextcloudlab.kickytime.util;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Component
 public class CognitoUserInfoClient {
@@ -25,5 +26,6 @@ public class CognitoUserInfoClient {
                 .body(UserInfo.class);
     }
 
-    public record UserInfo(String email, String nickname, @JsonProperty("email_verified") Boolean emailVerified) {}
+    public record UserInfo(
+            String email, String nickname, @JsonProperty("email_verified") Boolean emailVerified) {}
 }

--- a/src/main/java/com/nextcloudlab/kickytime/util/CognitoUserInfoClient.java
+++ b/src/main/java/com/nextcloudlab/kickytime/util/CognitoUserInfoClient.java
@@ -1,5 +1,6 @@
 package com.nextcloudlab.kickytime.util;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
@@ -24,5 +25,5 @@ public class CognitoUserInfoClient {
                 .body(UserInfo.class);
     }
 
-    public record UserInfo(String email, String nickname) {}
+    public record UserInfo(String email, String nickname, @JsonProperty("email_verified") Boolean emailVerified) {}
 }


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- Cognito userinfo 응답값을 기반으로 회원가입/로그인 시 email_verified 값이 DB에 반영되도록 기능을 구현했습니다.

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- CognitoUserInfoClient.UserInfo DTO에 email_verified 필드 매핑 (@JsonProperty)
- UserController의 /signin-up API에서 email_verified 값 추출 후 UserService로 전달
- UserService.findOrCreateUser 로직 개선
   - 신규 생성 시 emailVerified 저장
   - 기존 유저는 false → true 승격 처리
 - UserDto에 emailVerified 필드 추가하여 응답에 포함
 - UserServiceTest 수정/보완
   - 신규 생성 시 emailVerified 값 저장 확인
   - 기존 유저가 false일 때 로그인 시 true로 승격되는 시나리오 테스트 추가

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. Cognito Hosted UI로 회원가입 후, /api/users/signin-up API 호출 → DB에 email_verified=true 저장 확인
2. UserServiceTest 전체 실행 → 성공 여부 확인

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함
- [x] 필요 시 문서 업데이트 완료
- [x] 관련 이슈에 연결함

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #56 
