### PR TITLE
feat(admin): Cognito 사용자 풀 → DB 백필 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation("software.amazon.awssdk:cognitoidentityprovider:2.25.61")
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 	id 'checkstyle'
 }
 
-group = 'com.kickytime'
+group = 'com.nextcloudlab.kickytime'
 version = '0.0.1-SNAPSHOT'
 
 java {

--- a/src/main/java/com/nextcloudlab/kickytime/config/CognitoAdminClientConfig.java
+++ b/src/main/java/com/nextcloudlab/kickytime/config/CognitoAdminClientConfig.java
@@ -1,0 +1,17 @@
+package com.nextcloudlab.kickytime.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+
+@Configuration
+public class CognitoAdminClientConfig {
+    @Bean
+    public CognitoIdentityProviderClient cognitoIdentityProviderClient(
+            @Value("${app.cognito.region}") String region) {
+        return CognitoIdentityProviderClient.builder().region(Region.of(region)).build();
+    }
+}

--- a/src/main/java/com/nextcloudlab/kickytime/user/controller/UserAdminController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/controller/UserAdminController.java
@@ -1,0 +1,53 @@
+package com.nextcloudlab.kickytime.user.controller;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nextcloudlab.kickytime.user.entity.RoleEnum;
+import com.nextcloudlab.kickytime.user.repository.UserRepository;
+import com.nextcloudlab.kickytime.user.service.CognitoBackfillService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/admin/users")
+@RequiredArgsConstructor
+public class UserAdminController {
+    private final CognitoBackfillService backfillService;
+    private final UserRepository userRepository;
+
+    @PostMapping("/backfill-cognito")
+    public ResponseEntity<CognitoBackfillService.BackfillReport> backfillAll(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestParam(defaultValue = "false") boolean confirm) {
+        if (!confirm) {
+            throw new ResponseStatusException(BAD_REQUEST, "실행하려면 ?confirm=true 를 붙여주세요.");
+        }
+
+        String cognitoSub = (jwt != null) ? jwt.getClaimAsString("sub") : null;
+        if (cognitoSub == null || cognitoSub.isBlank()) {
+            throw new ResponseStatusException(UNAUTHORIZED, "유효한 인증 토큰이 필요합니다.");
+        }
+
+        boolean isAdmin =
+                userRepository
+                        .findByCognitoSub(cognitoSub)
+                        .map(u -> u.getRole() == RoleEnum.ADMIN)
+                        .orElse(false);
+
+        if (!isAdmin) {
+            throw new ResponseStatusException(FORBIDDEN, "관리자만 실행할 수 있습니다.");
+        }
+
+        var report = backfillService.backfillAllUsers();
+        return ResponseEntity.ok(report);
+    }
+}

--- a/src/main/java/com/nextcloudlab/kickytime/user/service/CognitoBackfillService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/service/CognitoBackfillService.java
@@ -1,0 +1,124 @@
+package com.nextcloudlab.kickytime.user.service;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.nextcloudlab.kickytime.user.entity.User;
+import com.nextcloudlab.kickytime.user.repository.UserRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CognitoBackfillService {
+    private final CognitoIdentityProviderClient cognito;
+    private final UserRepository userRepository;
+
+    @Value("${app.cognito.user-pool-id}")
+    private String userPoolId;
+
+    public BackfillReport backfillAllUsers() {
+        return backfillReport();
+    }
+
+    public BackfillReport backfillReport() {
+        int processed = 0, created = 0, updated = 0;
+
+        String token = null;
+        do {
+            ListUsersRequest request =
+                    ListUsersRequest.builder()
+                            .userPoolId(userPoolId)
+                            .limit(60)
+                            .paginationToken(token)
+                            .build();
+
+            ListUsersResponse response = cognito.listUsers(request);
+
+            for (UserType u : response.users()) {
+                processed++;
+                BackfillResult r = upsertOne(u);
+                switch (r) {
+                    case CREATED -> created++;
+                    case UPDATED -> updated++;
+                    case UNCHANGED -> {}
+                }
+            }
+            token = response.paginationToken();
+        } while (token != null);
+
+        return new BackfillReport(processed, created, updated);
+    }
+
+    @Transactional
+    BackfillResult upsertOne(UserType u) {
+        String cognitoSub = attr(u, "sub");
+        String email = attr(u, "email");
+        String nickname = attr(u, "nickname");
+        boolean emailVerified = "true".equalsIgnoreCase(attr(u, "email_verified"));
+
+        if (cognitoSub == null || email == null) {
+            log.warn(
+                    "Skip user with missing sub/email. username={}, status={}",
+                    u.username(),
+                    u.userStatusAsString());
+            return BackfillResult.UNCHANGED;
+        }
+
+        Optional<User> existOpt = userRepository.findByCognitoSub(cognitoSub);
+        if (existOpt.isEmpty()) {
+            User newUser = new User();
+            newUser.setCognitoSub(cognitoSub);
+            newUser.setEmail(email);
+            newUser.setNickname(nickname);
+            newUser.setEmailVerified(emailVerified);
+            userRepository.save(newUser);
+            return BackfillResult.CREATED;
+        } else {
+            User ex = existOpt.get();
+            boolean dirty = false;
+
+            if (email != null && !email.equals(ex.getEmail())) {
+                ex.setEmail(email);
+                dirty = true;
+            }
+            if (nickname != null && !nickname.equals(ex.getNickname())) {
+                ex.setNickname(nickname);
+                dirty = true;
+            }
+            if (emailVerified && !ex.isEmailVerified()) {
+                ex.setEmailVerified(true);
+                dirty = true;
+            }
+
+            if (dirty) {
+                userRepository.save(ex);
+                return BackfillResult.UPDATED;
+            }
+            return BackfillResult.UNCHANGED;
+        }
+    }
+
+    private String attr(UserType u, String key) {
+        return u.attributes().stream()
+                .filter(a -> key.equals(a.name()))
+                .map(AttributeType::value)
+                .findFirst()
+                .orElse(null);
+    }
+
+    public enum BackfillResult {
+        CREATED,
+        UPDATED,
+        UNCHANGED
+    }
+
+    public record BackfillReport(int processed, int created, int updated) {}
+}


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- Cognito User Pool의 전체 사용자를 RDS DB에 일괄 동기화하는 백필 기능 추가

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- build.gradle : implementation("software.amazon.awssdk:cognitoidentityprovider:2.25.61")
- config : CognitoAdminClientConfig: CognitoIdentityProviderClient Bean 등록
- service : CognitoBackfillService
   - backfillAllUsers(): ListUsers 페이지네이션 및 업서트, 리포트 반환
   - upsertOne(UserType): sub/email 검증, INSERT/UPDATE
- controller : UserAdminController
   - POST /api/admin/users/backfill-cognito?confirm=true
   - 컨트롤러 내부에서 토큰의 sub로 DB 조회 → RoleEnum.ADMIN 확인 → 실행

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. 관리자 로그인(우리 DB에서 role == ADMIN)
2. POSTMAN 테스트 → POST /api/admin/users/backfill-cognito?confirm=true
3. 응답확인
`{ "processed": 2450, "created": 2380, "updated": 60 }`

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함
- [x] 필요 시 문서 업데이트 완료
- [x] 관련 이슈에 연결함

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #58 
