### PR TITLE
🏗️ setup: ecr, ecs repository_dispatch 방식으로 변경 (트리거)

### DIFF
--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -1,9 +1,8 @@
 name: ECR - Build & Push
 
 on:
-  workflow_run:
-    workflows: ["CI"]   # ← 여기 'CI 워크플로우의 name'을 정확히 넣어줘
-    types: [completed]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -11,7 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write   # repository_dispatch에 필요
 
 env:
   AWS_REGION: ap-northeast-2
@@ -19,18 +18,12 @@ env:
 
 jobs:
   build_and_push:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'develop' }}
     runs-on: ubuntu-latest
-    env:
-      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
 
     steps:
-      - name: Checkout target commit (from CI)
+      - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
 
-      # 🔥 NEW: Docker Buildx 설정 (멀티 플랫폼 지원)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -45,11 +38,10 @@ jobs:
         id: ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Set TAG from head_sha
+      - name: Set TAG from commit SHA
         id: tag
-        run: echo "TAG=${HEAD_SHA::12}" >> $GITHUB_OUTPUT
+        run: echo "TAG=${GITHUB_SHA::12}" >> $GITHUB_OUTPUT
 
-      # 🔥 MODIFIED: ARM64 빌드로 변경
       - name: Build & Push ARM64 image
         id: build
         run: |
@@ -59,9 +51,6 @@ jobs:
           IMAGE_URI="$REGISTRY/${{ env.ECR_REPOSITORY }}:$TAG"
           LATEST_URI="$REGISTRY/${{ env.ECR_REPOSITORY }}:latest"
 
-          echo "Building ARM64 image: $IMAGE_URI (commit=$HEAD_SHA)"
-          
-          # ARM64 플랫폼으로 빌드 및 푸시
           docker buildx build \
             --platform linux/arm64 \
             --push \
@@ -70,32 +59,36 @@ jobs:
             .
 
           echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
-          echo "Successfully built and pushed ARM64 image"
 
-      # 🔥 NEW: 이미지 아키텍처 확인
       - name: Verify ARM64 architecture
         run: |
           REGISTRY="${{ steps.ecr.outputs.registry }}"
           TAG="${{ steps.tag.outputs.TAG }}"
           IMAGE_URI="$REGISTRY/${{ env.ECR_REPOSITORY }}:$TAG"
-          
-          echo "=== Verifying image architecture ==="
-          docker manifest inspect "$IMAGE_URI" | grep -A 10 '"architecture"'
-          
-          # ARM64 확인
           ARCH=$(docker manifest inspect "$IMAGE_URI" | jq -r '.manifests[0].platform.architecture // .architecture')
-          if [ "$ARCH" = "arm64" ]; then
-            echo "✅ Confirmed: Image is ARM64"
-          else
-            echo "❌ Error: Image architecture is $ARCH, expected arm64"
-            exit 1
-          fi
+          [ "$ARCH" = "arm64" ] || (echo "Expected arm64, got $ARCH" && exit 1)
+
+      # repository_dispatch 전송 + HTTP 204 확인
+      - name: Trigger ECS Deploy via repository_dispatch
+        if: success()
+        run: |
+          set -e
+          image_uri="${{ steps.build.outputs.IMAGE_URI }}"
+          tag="${{ steps.tag.outputs.TAG }}"
+          branch="${{ github.ref_name }}"
+          sha="${{ github.sha }}"
+
+          resp=$(curl -s -o /tmp/resp.txt -w "%{http_code}" -X POST \
+            "https://api.github.com/repos/${{ github.repository }}/dispatches" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -d "{\"event_type\":\"deploy-ecs\",\"client_payload\":{\"image_uri\":\"$image_uri\",\"tag\":\"$tag\",\"branch\":\"$branch\",\"sha\":\"$sha\"}}")
+          [ "$resp" = "204" ] || (cat /tmp/resp.txt && exit 1)
 
       - name: Summary
         run: |
-          echo "### ✅ ECR Push Completed (ARM64)" >> $GITHUB_STEP_SUMMARY
-          echo "- Repo: \`${{ env.ECR_REPOSITORY }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Tag: \`${{ steps.tag.outputs.TAG }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Commit: \`${{ env.HEAD_SHA }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Platform: \`linux/arm64\`" >> $GITHUB_STEP_SUMMARY
+          echo "### ✅ ECR Push & Dispatch OK" >> $GITHUB_STEP_SUMMARY
+          echo "- Repo:  \`${{ env.ECR_REPOSITORY }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Tag:   \`${{ steps.tag.outputs.TAG }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Image: \`${{ steps.build.outputs.IMAGE_URI }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Sent:  \`repository_dispatch: deploy-ecs\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -1,13 +1,12 @@
-name: ECS - Deploy
+name: ECS - Deploy (dispatch)
 
 on:
-  workflow_run:
-    workflows: ["ECR - Build & Push"]  # ← ECR 워크플로우 'name' 정확히 입력
-    types: [completed]
+  repository_dispatch:
+    types: [deploy-ecs]
   workflow_dispatch:
 
 concurrency:
-  group: ecs-main
+  group: ecs-deploy
   cancel-in-progress: false
 
 permissions:
@@ -15,74 +14,69 @@ permissions:
 
 env:
   AWS_REGION: ap-northeast-2
-  ECR_REPOSITORY: kickytime-repo        # ECR 리포 이름
-  ECS_CLUSTER: kickytime-cluster        # ECS 클러스터 이름
-  ECS_SERVICE: kickytime-task-service   # ECS 서비스 이름
-  TASK_FAMILY: kickytime-task           # 태스크 정의 패밀리
-  CONTAINER_NAME: kickytime-ecr         # TD 안 컨테이너 이름(정확히 일치)
+  ECR_REPOSITORY: kickytime-repo
+  ECS_CLUSTER: kickytime-cluster
+  ECS_SERVICE: kickytime-task-service
+  TASK_FAMILY: kickytime-task
+  CONTAINER_NAME: kickytime-ecr
 
 jobs:
   deploy:
-    # ECR 워크플로우가 '성공'이고, 대상 브랜치가 main일 때만 실행
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'develop' }}
     runs-on: ubuntu-latest
     env:
-      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      PAYLOAD_IMAGE_URI: ${{ github.event.client_payload.image_uri }}
+      PAYLOAD_TAG:       ${{ github.event.client_payload.tag }}
+      PAYLOAD_BRANCH:    ${{ github.event.client_payload.branch }}
+      PAYLOAD_SHA:       ${{ github.event.client_payload.sha }}
 
     steps:
-      - name: Checkout same commit (from ECR build)
+      - name: Gate - only deploy for main
+        id: gate
+        run: |
+          if [ "$PAYLOAD_BRANCH" = "main" ]; then
+            echo "GO=true" >> $GITHUB_OUTPUT
+          else
+            echo "GO=false" >> $GITHUB_OUTPUT
+            echo "Non-deploy branch: $PAYLOAD_BRANCH"
+          fi
+
+      - name: Checkout (same commit as build)
+        if: steps.gate.outputs.GO == 'true'
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.HEAD_SHA }}
+          ref: ${{ env.PAYLOAD_SHA }}
 
-      - name: Configure AWS credentials (Access Keys)
+      - name: Configure AWS credentials
+        if: steps.gate.outputs.GO == 'true'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-access-key-id:     ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region:            ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
+        if: steps.gate.outputs.GO == 'true'
         id: ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
-
-      # ECR에서 사용한 것과 동일한 태그(HEAD_SHA 12자리)로 이미지 URI를 재구성
-      - name: Compute IMAGE_URI (same tag as ECR)
-        id: tag
-        run: |
-          TAG=${HEAD_SHA::12}
-          echo "TAG=$TAG" >> $GITHUB_OUTPUT
-          echo "IMAGE_URI=${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${TAG}" >> $GITHUB_OUTPUT
-
       - name: Describe current Task Definition
+        if: steps.gate.outputs.GO == 'true'
         run: |
           aws ecs describe-task-definition \
             --task-definition "${{ env.TASK_FAMILY }}" \
             --query 'taskDefinition' > td.json
 
-      # 🔥 ARM64 아키텍처 명시적 설정 추가
-      - name: Patch image & ensure ARM64 platform (keep env/secrets)
+      - name: Patch image & ensure ARM64 platform
+        if: steps.gate.outputs.GO == 'true'
         run: |
-          jq --arg NAME "${{ env.CONTAINER_NAME }}" --arg IMG "${{ steps.tag.outputs.IMAGE_URI }}" '
+          jq --arg NAME "${{ env.CONTAINER_NAME }}" --arg IMG "${PAYLOAD_IMAGE_URI}" '
             .containerDefinitions |= map(if .name == $NAME then .image = $IMG else . end)
-            | .runtimePlatform = {
-                "cpuArchitecture": "ARM64",
-                "operatingSystemFamily": "LINUX"
-              }
+            | .runtimePlatform = {"cpuArchitecture":"ARM64","operatingSystemFamily":"LINUX"}
             | del(.taskDefinitionArn,.revision,.status,.requiresAttributes,.compatibilities,.registeredAt,.registeredBy)
           ' td.json > td-new.json
 
-      # 디버깅: 태스크 정의 내용 확인
-      - name: Verify Task Definition content
-        run: |
-          echo "=== Task Definition Platform & Container Info ==="
-          jq '.runtimePlatform' td-new.json
-          jq '.containerDefinitions[] | {name: .name, image: .image, cpu: .cpu, memory: .memory}' td-new.json
-
       - name: Register new Task Definition
+        if: steps.gate.outputs.GO == 'true'
         id: register
         run: |
           NEW_TD_ARN=$(aws ecs register-task-definition \
@@ -90,9 +84,9 @@ jobs:
             --query 'taskDefinition.taskDefinitionArn' \
             --output text)
           echo "TASK_DEF_ARN=$NEW_TD_ARN" >> $GITHUB_OUTPUT
-          echo "New TD (ARM64): $NEW_TD_ARN"
 
       - name: Update service (rolling deployment)
+        if: steps.gate.outputs.GO == 'true'
         run: |
           aws ecs update-service \
             --cluster "${{ env.ECS_CLUSTER }}" \
@@ -100,101 +94,25 @@ jobs:
             --task-definition "${{ steps.register.outputs.TASK_DEF_ARN }}" \
             --force-new-deployment
 
-      # 서비스 안정화 대기 시간을 줄이고 실패 시 디버깅 정보 수집
-      - name: Wait for deployment (with timeout)
-        id: wait_deploy
+      - name: Wait for deployment (timeout 10m)
+        if: steps.gate.outputs.GO == 'true'
+        id: wait
         continue-on-error: true
         run: |
           timeout 600 aws ecs wait services-stable \
             --cluster "${{ env.ECS_CLUSTER }}" \
             --services "${{ env.ECS_SERVICE }}" || echo "WAIT_FAILED=true" >> $GITHUB_OUTPUT
 
-      # 배포 실패 시 디버깅 정보 수집
-      - name: Debug failed deployment
-        if: steps.wait_deploy.outputs.WAIT_FAILED == 'true'
+      - name: Summary
+        if: steps.gate.outputs.GO == 'true'
         run: |
-          echo "🔍 Deployment failed, collecting debug info..."
-          
-          # 서비스 상태 확인
-          echo "=== Service Description ==="
-          aws ecs describe-services \
-            --cluster "${{ env.ECS_CLUSTER }}" \
-            --services "${{ env.ECS_SERVICE }}"
-          
-          # 최근 태스크들 상태 확인
-          echo "=== Recent Tasks ==="
-          aws ecs list-tasks \
-            --cluster "${{ env.ECS_CLUSTER }}" \
-            --service-name "${{ env.ECS_SERVICE }}" \
-            --max-items 5 \
-            --query 'taskArns[]' --output text | \
-          xargs -I {} aws ecs describe-tasks \
-            --cluster "${{ env.ECS_CLUSTER }}" \
-            --tasks {} \
-            --query 'tasks[0].{TaskArn:taskArn,LastStatus:lastStatus,HealthStatus:healthStatus,StoppedReason:stoppedReason,Platform:runtimePlatform}'
-          
-          # 서비스 이벤트 확인
-          echo "=== Service Events ==="
-          aws ecs describe-services \
-            --cluster "${{ env.ECS_CLUSTER }}" \
-            --services "${{ env.ECS_SERVICE }}" \
-            --query 'services[0].events[:10]'
-
-      - name: Check task definition details
-        if: steps.wait_deploy.outputs.WAIT_FAILED == 'true'
-        run: |
-          echo "=== Task Definition Details ==="
-          aws ecs describe-task-definition \
-            --task-definition "${{ steps.register.outputs.TASK_DEF_ARN }}" \
-            --query 'taskDefinition.{
-              Family: family,
-              Revision: revision,
-              Cpu: cpu,
-              Memory: memory,
-              Platform: runtimePlatform,
-              Containers: containerDefinitions[].{
-                Name: name,
-                Image: image,
-                Cpu: cpu,
-                Memory: memory,
-                Essential: essential,
-                PortMappings: portMappings,
-                HealthCheck: healthCheck
-              }
-            }'
-
-      - name: Rollback on failure
-        if: steps.wait_deploy.outputs.WAIT_FAILED == 'true'
-        run: |
-          echo "🔄 Rolling back to previous task definition..."
-          
-          # 이전 태스크 정의 찾기
-          PREV_TD=$(aws ecs describe-services \
-            --cluster "${{ env.ECS_CLUSTER }}" \
-            --services "${{ env.ECS_SERVICE }}" \
-            --query 'services[0].taskDefinition' \
-            --output text)
-          
-          echo "Rolling back to: $PREV_TD"
-          
-          aws ecs update-service \
-            --cluster "${{ env.ECS_CLUSTER }}" \
-            --service "${{ env.ECS_SERVICE }}" \
-            --task-definition "$PREV_TD"
-
-      - name: Final status and summary
-        run: |
-          if [ "${{ steps.wait_deploy.outputs.WAIT_FAILED }}" == "true" ]; then
+          if [ "${{ steps.wait.outputs.WAIT_FAILED }}" == "true" ]; then
             echo "### ❌ ECS Deploy Failed" >> $GITHUB_STEP_SUMMARY
-            echo "Check the debug output above for details." >> $GITHUB_STEP_SUMMARY
-            echo "- Issue: Likely ARM64 architecture mismatch" >> $GITHUB_STEP_SUMMARY
-            echo "- Next step: Verify ECR build uses ARM64 platform" >> $GITHUB_STEP_SUMMARY
             exit 1
           else
             echo "### ✅ ECS Deploy Completed (ARM64)" >> $GITHUB_STEP_SUMMARY
-            echo "- Cluster: \`${{ env.ECS_CLUSTER }}\`" >> $GITHUB_STEP_SUMMARY
-            echo "- Service: \`${{ env.ECS_SERVICE }}\`" >> $GITHUB_STEP_SUMMARY
-            echo "- TD: \`${{ steps.register.outputs.TASK_DEF_ARN }}\`" >> $GITHUB_STEP_SUMMARY
-            echo "- Image: \`${{ steps.tag.outputs.IMAGE_URI }}\`" >> $GITHUB_STEP_SUMMARY
-            echo "- Platform: \`ARM64/LINUX\`" >> $GITHUB_STEP_SUMMARY
+            echo "- Cluster: \`${{ env.ECS_CLUSTER }}\`"
+            echo "- Service: \`${{ env.ECS_SERVICE }}\`"
+            echo "- TD: \`${{ steps.register.outputs.TASK_DEF_ARN }}\`"
+            echo "- Image: \`${PAYLOAD_IMAGE_URI}\`"
           fi


### PR DESCRIPTION
## 📌 PR 개요

* ECR 빌드 & 푸시가 완료되면 `repository_dispatch` 이벤트를 통해 ECS 배포 워크플로우가 자동 실행되도록 트리거 방식을 적용
* 기존 수동/브랜치 의존 배포 플로우를 개선하여 **ECR → ECS 자동 연동 파이프라인** 구축

## 🔍 변경 사항

* `ECR - Build & Push` 워크플로우 완료 시 `deploy-ecs` 이벤트를 발생시키도록 설정
* `ECS - Deploy` 워크플로우가 `repository_dispatch` 이벤트를 수신하면 자동 실행되도록 변경
* 브랜치 기준을 `main`으로 통합하여 배포 기준 명확화

## 🧪 테스트 방법

1. `main` 브랜치에 커밋/머지
2. `ECR - Build & Push` 워크플로우 실행 → 이미지 빌드 & 푸시 확인
3. `ECS - Deploy` 워크플로우 자동 실행 확인 → ECS 서비스에서 새로운 태스크 반영 여부 검증

## ✅ 체크리스트

* [x] ECR 푸시 시 ECS 배포 트리거가 정상 작동함
* [x] 기존 ECS 배포 플로우와 충돌 없음
* [x] 코드 컨벤션(Prettier/ESLint, Checkstyle 등) 통과
* [x] 필요 시 문서 업데이트 완료
* [x] 관련 이슈에 연결함

## 📎 참고 이슈

Ref: #

