### PR TITLE
🐛 fix: springdoc OpenAPI 엔드포인트 404 오류 해결

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,3 +53,14 @@ logging:
 
 server:
   port: 8080
+
+# SpringDoc OpenAPI 설정
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  packages-to-scan: com.nextcloudlab.kickytime
+  


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- SpringDoc OpenAPI 설정을 추가하여 `/v3/api-docs/**` 엔드포인트의 404 오류를 해결

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- SpringDoc OpenAPI 설정 추가
- `/v3/api-docs` 엔드포인트 경로 명시적 설정
- Swagger UI 경로 및 정렬 옵션 설정
- API 문서 스캔 패키지 범위 지정
- 
## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. 애플리케이션 재시작
2. http://localhost:8080/v3/api-docs 에 접속하여 API 문서 JSON이 정상 응답하는지 확인
3. http://localhost:8080/swagger-ui/index.html 에 접속하여 Swagger UI가 정상 표시되는지 확인
4. 기존 /actuator/health 엔드포인트도 정상 작동하는지 확인합니다

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #
