### PR TITLE
✨ feat(security): 분리된 권한 검증을 @PreAuthorize 기반으로 분리

### DIFF
--- a/src/main/java/com/nextcloudlab/kickytime/config/JwtAuthConverterConfig.java
+++ b/src/main/java/com/nextcloudlab/kickytime/config/JwtAuthConverterConfig.java
@@ -1,7 +1,8 @@
 package com.nextcloudlab.kickytime.config;
 
-import com.nextcloudlab.kickytime.user.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.core.GrantedAuthority;
@@ -9,8 +10,9 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
+import com.nextcloudlab.kickytime.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor
@@ -22,23 +24,28 @@ public class JwtAuthConverterConfig {
     public JwtAuthenticationConverter jwtAuthenticationConverter() {
         var converter = new JwtAuthenticationConverter();
 
-        converter.setJwtGrantedAuthoritiesConverter((Jwt jwt) -> {
-            Set<GrantedAuthority> authorities =new LinkedHashSet<>();
+        converter.setJwtGrantedAuthoritiesConverter(
+                (Jwt jwt) -> {
+                    Set<GrantedAuthority> authorities = new LinkedHashSet<>();
 
-            String cognitoSub = jwt.getClaimAsString("sub");
-            if (cognitoSub == null || cognitoSub.isBlank()) {
-                return authorities;
-            }
+                    String cognitoSub = jwt.getClaimAsString("sub");
+                    if (cognitoSub == null || cognitoSub.isBlank()) {
+                        return authorities;
+                    }
 
-            userRepository.findByCognitoSub(cognitoSub).ifPresent(user -> {
-                var role = user.getRole();
-                if (role != null) {
-                    authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
-                }
-            });
+                    userRepository
+                            .findByCognitoSub(cognitoSub)
+                            .ifPresent(
+                                    user -> {
+                                        var role = user.getRole();
+                                        if (role != null) {
+                                            authorities.add(
+                                                    new SimpleGrantedAuthority("ROLE_" + role));
+                                        }
+                                    });
 
-            return authorities;
-        });
+                    return authorities;
+                });
 
         return converter;
     }

--- a/src/main/java/com/nextcloudlab/kickytime/config/JwtAuthConverterConfig.java
+++ b/src/main/java/com/nextcloudlab/kickytime/config/JwtAuthConverterConfig.java
@@ -1,0 +1,45 @@
+package com.nextcloudlab.kickytime.config;
+
+import com.nextcloudlab.kickytime.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Configuration
+@RequiredArgsConstructor
+public class JwtAuthConverterConfig {
+
+    private final UserRepository userRepository;
+
+    @Bean
+    public JwtAuthenticationConverter jwtAuthenticationConverter() {
+        var converter = new JwtAuthenticationConverter();
+
+        converter.setJwtGrantedAuthoritiesConverter((Jwt jwt) -> {
+            Set<GrantedAuthority> authorities =new LinkedHashSet<>();
+
+            String cognitoSub = jwt.getClaimAsString("sub");
+            if (cognitoSub == null || cognitoSub.isBlank()) {
+                return authorities;
+            }
+
+            userRepository.findByCognitoSub(cognitoSub).ifPresent(user -> {
+                var role = user.getRole();
+                if (role != null) {
+                    authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
+                }
+            });
+
+            return authorities;
+        });
+
+        return converter;
+    }
+}

--- a/src/main/java/com/nextcloudlab/kickytime/config/SecurityConfig.java
+++ b/src/main/java/com/nextcloudlab/kickytime/config/SecurityConfig.java
@@ -43,10 +43,12 @@ public class SecurityConfig {
                                         .anyRequest()
                                         .permitAll())
                 .oauth2ResourceServer(
-                        oauth2 -> oauth2.jwt(jwt -> jwt
-                                .decoder(accessTokenDecoder())
-                                .jwtAuthenticationConverter(jwtAuthConverter)
-                        ))
+                        oauth2 ->
+                                oauth2.jwt(
+                                        jwt ->
+                                                jwt.decoder(accessTokenDecoder())
+                                                        .jwtAuthenticationConverter(
+                                                                jwtAuthConverter)))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable);
         return http.build();

--- a/src/main/java/com/nextcloudlab/kickytime/config/SecurityConfig.java
+++ b/src/main/java/com/nextcloudlab/kickytime/config/SecurityConfig.java
@@ -4,17 +4,26 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@EnableMethodSecurity
 public class SecurityConfig {
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuerUri;
+
+    private final JwtAuthenticationConverter jwtAuthConverter;
+
+    public SecurityConfig(JwtAuthenticationConverter jwtAuthConverter) {
+        this.jwtAuthConverter = jwtAuthConverter;
+    }
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -34,7 +43,10 @@ public class SecurityConfig {
                                         .anyRequest()
                                         .permitAll())
                 .oauth2ResourceServer(
-                        oauth2 -> oauth2.jwt(jwt -> jwt.decoder(accessTokenDecoder())))
+                        oauth2 -> oauth2.jwt(jwt -> jwt
+                                .decoder(accessTokenDecoder())
+                                .jwtAuthenticationConverter(jwtAuthConverter)
+                        ))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable);
         return http.build();

--- a/src/main/java/com/nextcloudlab/kickytime/match/service/MatchService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/service/MatchService.java
@@ -16,7 +16,6 @@ import com.nextcloudlab.kickytime.match.entity.MatchParticipant;
 import com.nextcloudlab.kickytime.match.entity.MatchStatus;
 import com.nextcloudlab.kickytime.match.repository.MatchParticipantRepository;
 import com.nextcloudlab.kickytime.match.repository.MatchRepository;
-import com.nextcloudlab.kickytime.user.entity.RoleEnum;
 import com.nextcloudlab.kickytime.user.entity.User;
 import com.nextcloudlab.kickytime.user.repository.UserRepository;
 

--- a/src/main/java/com/nextcloudlab/kickytime/match/service/MatchService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/service/MatchService.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,15 +46,12 @@ public class MatchService {
 
     // 경기 개설
     @Transactional
+    @PreAuthorize("hasRole('ADMIN')")
     public void createMatch(MatchCreateRequestDto requestDto) {
         User user =
                 userRepository
                         .findById(requestDto.createdBy())
                         .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-
-        if (user.getRole() != RoleEnum.ADMIN) {
-            throw new IllegalStateException("관리자 권한이 있는 사용자만 경기를 개설할 수 있습니다.");
-        }
 
         Match match = new Match();
         match.setMatchStatus(MatchStatus.OPEN);

--- a/src/main/java/com/nextcloudlab/kickytime/user/controller/UserAdminController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/controller/UserAdminController.java
@@ -4,16 +4,12 @@ import static org.springframework.http.HttpStatus.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-import com.nextcloudlab.kickytime.user.entity.RoleEnum;
-import com.nextcloudlab.kickytime.user.repository.UserRepository;
 import com.nextcloudlab.kickytime.user.service.CognitoBackfillService;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/nextcloudlab/kickytime/user/controller/UserAdminController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/controller/UserAdminController.java
@@ -3,6 +3,7 @@ package com.nextcloudlab.kickytime.user.controller;
 import static org.springframework.http.HttpStatus.*;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,29 +23,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserAdminController {
     private final CognitoBackfillService backfillService;
-    private final UserRepository userRepository;
 
     @PostMapping("/backfill-cognito")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<CognitoBackfillService.BackfillReport> backfillAll(
-            @AuthenticationPrincipal Jwt jwt,
             @RequestParam(defaultValue = "false") boolean confirm) {
         if (!confirm) {
             throw new ResponseStatusException(BAD_REQUEST, "실행하려면 ?confirm=true 를 붙여주세요.");
-        }
-
-        String cognitoSub = (jwt != null) ? jwt.getClaimAsString("sub") : null;
-        if (cognitoSub == null || cognitoSub.isBlank()) {
-            throw new ResponseStatusException(UNAUTHORIZED, "유효한 인증 토큰이 필요합니다.");
-        }
-
-        boolean isAdmin =
-                userRepository
-                        .findByCognitoSub(cognitoSub)
-                        .map(u -> u.getRole() == RoleEnum.ADMIN)
-                        .orElse(false);
-
-        if (!isAdmin) {
-            throw new ResponseStatusException(FORBIDDEN, "관리자만 실행할 수 있습니다.");
         }
 
         var report = backfillService.backfillAllUsers();

--- a/src/main/java/com/nextcloudlab/kickytime/user/controller/UserController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.nextcloudlab.kickytime.user.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
@@ -11,15 +12,11 @@ import com.nextcloudlab.kickytime.util.CognitoUserInfoClient;
 
 @RestController
 @RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
     private final CognitoUserInfoClient userInfoClient;
-
-    public UserController(UserService userService, CognitoUserInfoClient userInfoClient) {
-        this.userService = userService;
-        this.userInfoClient = userInfoClient;
-    }
 
     @PostMapping("/signin-up")
     public User signInUp(@AuthenticationPrincipal Jwt accessToken) {

--- a/src/main/java/com/nextcloudlab/kickytime/user/controller/UserController.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/controller/UserController.java
@@ -1,6 +1,5 @@
 package com.nextcloudlab.kickytime.user.controller;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
@@ -9,6 +8,8 @@ import com.nextcloudlab.kickytime.user.dto.UserDto;
 import com.nextcloudlab.kickytime.user.entity.User;
 import com.nextcloudlab.kickytime.user.service.UserService;
 import com.nextcloudlab.kickytime.util.CognitoUserInfoClient;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/users")

--- a/src/test/java/com/nextcloudlab/kickytime/match/service/MatchServiceSecurityTest.java
+++ b/src/test/java/com/nextcloudlab/kickytime/match/service/MatchServiceSecurityTest.java
@@ -1,12 +1,12 @@
 package com.nextcloudlab.kickytime.match.service;
 
-import com.nextcloudlab.kickytime.match.dto.MatchCreateRequestDto;
-import com.nextcloudlab.kickytime.match.entity.Match;
-import com.nextcloudlab.kickytime.match.repository.MatchParticipantRepository;
-import com.nextcloudlab.kickytime.match.repository.MatchRepository;
-import com.nextcloudlab.kickytime.user.entity.RoleEnum;
-import com.nextcloudlab.kickytime.user.entity.User;
-import com.nextcloudlab.kickytime.user.repository.UserRepository;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,12 +18,13 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.any;
+import com.nextcloudlab.kickytime.match.dto.MatchCreateRequestDto;
+import com.nextcloudlab.kickytime.match.entity.Match;
+import com.nextcloudlab.kickytime.match.repository.MatchParticipantRepository;
+import com.nextcloudlab.kickytime.match.repository.MatchRepository;
+import com.nextcloudlab.kickytime.user.entity.RoleEnum;
+import com.nextcloudlab.kickytime.user.entity.User;
+import com.nextcloudlab.kickytime.user.repository.UserRepository;
 
 @SpringBootTest
 @Import(MatchService.class) // 프록시가 적용된 실제 빈 주입
@@ -33,23 +34,18 @@ class MatchServiceSecurityTest {
     @EnableMethodSecurity // @PreAuthorize 활성화
     static class MethodSecurityTestConfig {}
 
-    @Autowired
-    MatchService matchService;
+    @Autowired MatchService matchService;
 
-    @MockitoBean
-    UserRepository userRepository;
-    @MockitoBean
-    MatchRepository matchRepository;
-    @MockitoBean
-    MatchParticipantRepository participantRepository;
+    @MockitoBean UserRepository userRepository;
+    @MockitoBean MatchRepository matchRepository;
+    @MockitoBean MatchParticipantRepository participantRepository;
 
     @Test
     @DisplayName("USER 권한으로 createMatch 호출 시 접근 거부")
     @WithMockUser(username = "user", roles = "USER")
-    void createMatch_forbidden_whenUserRoleIsUSER() {
+    void createMatchForbiddenWhenUserRoleIsUser() {
         // given
-        var dto = new MatchCreateRequestDto(2L,
-                LocalDateTime.now().plusDays(1), "서울", 10);
+        var dto = new MatchCreateRequestDto(2L, LocalDateTime.now().plusDays(1), "서울", 10);
 
         // userRepository가 호출되지 않더라도 상관 없지만, 혹시를 위해 준비
         var creator = new User();
@@ -65,10 +61,9 @@ class MatchServiceSecurityTest {
     @Test
     @DisplayName("ADMIN 권한으로 createMatch 호출 시 통과")
     @WithMockUser(username = "admin", roles = "ADMIN")
-    void createMatch_allowed_whenUserRoleIsADMIN() {
+    void createMatchAllowedWhenUserRoleIsAdmin() {
         // given
-        var dto = new MatchCreateRequestDto(1L,
-                LocalDateTime.now().plusDays(1), "서울", 10);
+        var dto = new MatchCreateRequestDto(1L, LocalDateTime.now().plusDays(1), "서울", 10);
 
         var admin = new User();
         admin.setId(1L);

--- a/src/test/java/com/nextcloudlab/kickytime/match/service/MatchServiceSecurityTest.java
+++ b/src/test/java/com/nextcloudlab/kickytime/match/service/MatchServiceSecurityTest.java
@@ -1,0 +1,82 @@
+package com.nextcloudlab.kickytime.match.service;
+
+import com.nextcloudlab.kickytime.match.dto.MatchCreateRequestDto;
+import com.nextcloudlab.kickytime.match.entity.Match;
+import com.nextcloudlab.kickytime.match.repository.MatchParticipantRepository;
+import com.nextcloudlab.kickytime.match.repository.MatchRepository;
+import com.nextcloudlab.kickytime.user.entity.RoleEnum;
+import com.nextcloudlab.kickytime.user.entity.User;
+import com.nextcloudlab.kickytime.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+
+@SpringBootTest
+@Import(MatchService.class) // 프록시가 적용된 실제 빈 주입
+class MatchServiceSecurityTest {
+
+    @TestConfiguration
+    @EnableMethodSecurity // @PreAuthorize 활성화
+    static class MethodSecurityTestConfig {}
+
+    @Autowired
+    MatchService matchService;
+
+    @MockitoBean
+    UserRepository userRepository;
+    @MockitoBean
+    MatchRepository matchRepository;
+    @MockitoBean
+    MatchParticipantRepository participantRepository;
+
+    @Test
+    @DisplayName("USER 권한으로 createMatch 호출 시 접근 거부")
+    @WithMockUser(username = "user", roles = "USER")
+    void createMatch_forbidden_whenUserRoleIsUSER() {
+        // given
+        var dto = new MatchCreateRequestDto(2L,
+                LocalDateTime.now().plusDays(1), "서울", 10);
+
+        // userRepository가 호출되지 않더라도 상관 없지만, 혹시를 위해 준비
+        var creator = new User();
+        creator.setId(2L);
+        creator.setRole(RoleEnum.USER);
+        given(userRepository.findById(2L)).willReturn(Optional.of(creator));
+
+        // when & then
+        assertThatThrownBy(() -> matchService.createMatch(dto))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한으로 createMatch 호출 시 통과")
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void createMatch_allowed_whenUserRoleIsADMIN() {
+        // given
+        var dto = new MatchCreateRequestDto(1L,
+                LocalDateTime.now().plusDays(1), "서울", 10);
+
+        var admin = new User();
+        admin.setId(1L);
+        admin.setRole(RoleEnum.ADMIN);
+        given(userRepository.findById(1L)).willReturn(Optional.of(admin));
+        given(matchRepository.save(any(Match.class))).willReturn(new Match());
+
+        // when (예외 없어야 통과)
+        matchService.createMatch(dto);
+    }
+}

--- a/src/test/java/com/nextcloudlab/kickytime/match/service/MatchServiceTest.java
+++ b/src/test/java/com/nextcloudlab/kickytime/match/service/MatchServiceTest.java
@@ -119,23 +119,6 @@ class MatchServiceTest {
     }
 
     @Test
-    @DisplayName("경기 개설 - 관리자 권한 없음 예외")
-    void createMatchNotAdminUser() {
-        // createRequestDto는 setter가 없으므로 새로운 인스턴스 생성
-        createRequestDto =
-                new MatchCreateRequestDto(
-                        2L,
-                        createRequestDto.matchDateTime(),
-                        createRequestDto.location(),
-                        createRequestDto.maxPlayers());
-        given(userRepository.findById(2L)).willReturn(Optional.of(regularUser));
-
-        assertThatThrownBy(() -> matchService.createMatch(createRequestDto))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("관리자 권한이 있는 사용자만 경기를 개설할 수 있습니다.");
-    }
-
-    @Test
     @DisplayName("경기 참여 - 성공")
     void joinMatchSuccess() {
         // given


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- 서비스/컨트롤러에 분산되어 있던 권한 검증(if/DB 조회) 을 제거하고, Spring Security 메서드 시큐리티(@PreAuthorize) 기반으로 인가 로직을 보안 계층으로 분리했습니다.
- JWT sub로 DB의 User.role을 조회해 ROLE_* 권한을 부여하는 JwtAuthConverterConfig 를 추가했습니다.
- 권한 분리에 맞춰 보안 경계 테스트를 추가하고, 기존 단위 테스트에서 의미가 사라진 권한 예외 검증을 정리했습니다.

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- Security
   - SecurityConfig: @EnableMethodSecurity 활성화, JwtAuthenticationConverter 연결.
   - JwtAuthConverterConfig(신규): JWT의 sub로 UserRepository 조회 → User.role(DB: USER|ADMIN)을 GrantedAuthority("ROLE_" + role)로 매핑.
- Controller / Service 인가 선언
   - UserAdminController: 하드코딩된 관리자 검증 제거 → @PreAuthorize("hasRole('ADMIN')")로 보호.
   - MatchService: createMatch() 내부의 admin if 제거 → @PreAuthorize("hasRole('ADMIN')")로 보호.
   - UserController: /signin-up, /me에 @PreAuthorize("isAuthenticated()") 명시(의도 드러냄).
-  Test
   - MatchServiceSecurityTest(신규): @EnableMethodSecurity + @WithMockUser로 ADMIN/USER 시나리오 검증.
   - 기존 MatchServiceTest의 “관리자 권한 없음 예외” 케이스 삭제/이관(서비스 내부 if 제거로 의미 소멸).
 

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1.단위 테스트 실행
- ./gradlew test
- MatchServiceTest 기존 비즈니스 로직 테스트 통과 확인.

2. 보안 경계 테스트 실행
- MatchServiceSecurityTest에서 아래 시나리오 확인:
   - @WithMockUser(roles="USER")로 createMatch() 호출 → AccessDeniedException 발생.
   - @WithMockUser(roles="ADMIN")로 createMatch() 호출 → 정상 통과.


## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작함
- [ ] 기존 기능에 문제가 없음
- [ ] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #82 
