### PR TITLE
🔧 config(deploy): EC2 배포 설정 및 Cognito 구성 갱신

### DIFF
--- a/.github/workflows/ec2.yml
+++ b/.github/workflows/ec2.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   AWS_REGION: ap-northeast-2
-  IMAGE: ${{ github.event.client_payload.image_uri || '077672914621.dkr.ecr.ap-northeast-2.amazonaws.com/kickytime-repo:latest' }}
+  IMAGE: ${{ github.event.client_payload.image_uri || '205366594951.dkr.ecr.ap-northeast-2.amazonaws.com/kickytime-repo:latest' }}
   TARGET_TAG_KEY: Role
   TARGET_TAG_VALUE: app
   PORT: "8080"
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo "Deploying image: $IMAGE"
           
-          aws ssm send-command \
+          COMMAND_ID=$(aws ssm send-command \
             --region $AWS_REGION \
             --document-name "AWS-RunShellScript" \
             --instance-ids $IDS_LIST \
@@ -66,9 +66,27 @@ jobs:
                 "  -e SPRING_DATASOURCE_URL=\"'${{ secrets.DB_URL }}'\" \\",
                 "  -e SPRING_DATASOURCE_USERNAME=\"'${{ secrets.DB_USERNAME }}'\" \\",
                 "  -e SPRING_DATASOURCE_PASSWORD=\"'${{ secrets.DB_PASSWORD }}'\" \\",
+                "  -e SPRING_JPA_HIBERNATE_DDL_AUTO=update \\",
                 "  \"'$IMAGE'\"",
-                "for i in $(seq 1 60); do curl -fsS http://127.0.0.1:'$PORT$HEALTH' && break || sleep 2; done"
+                "for i in $(seq 1 60); do curl -fsS http://127.0.0.1:'$PORT$HEALTH' && exit 0; sleep 2; done",
+                "docker logs --tail 200 kickytime || true",
+                "exit 1"
               ],
               "executionTimeout": ["1800"]
             }' \
-            --comment "Deploy $IMAGE"
+            --comment "Deploy $IMAGE" \
+            --query 'Command.CommandId' \
+            --output text)
+
+          for INSTANCE_ID in $IDS_LIST; do
+            aws ssm wait command-executed \
+              --region "$AWS_REGION" \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID"
+
+            aws ssm get-command-invocation \
+              --region "$AWS_REGION" \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query '{InstanceId:InstanceId,Status:Status,ResponseCode:ResponseCode,Output:StandardOutputContent,Error:StandardErrorContent}'
+          done

--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -107,13 +107,13 @@ jobs:
           branch="${{ github.ref_name }}"
           sha="${{ github.sha }}"
 
-          # ECS
-          resp=$(curl -s -o /tmp/resp.txt -w "%{http_code}" -X POST \
-            "https://api.github.com/repos/${{ github.repository }}/dispatches" \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -d "{\"event_type\":\"deploy-ecs\",\"client_payload\":{\"image_uri\":\"$image_uri\",\"tag\":\"$tag\",\"branch\":\"$branch\",\"sha\":\"$sha\"}}")
-          [ "$resp" = "204" ] || (echo "ECS dispatch failed:" && cat /tmp/resp.txt && exit 1)
+          # ECS 배포는 EC2 -> ECS 전환 단계에서 다시 활성화한다.
+          # resp=$(curl -s -o /tmp/resp.txt -w "%{http_code}" -X POST \
+          #   "https://api.github.com/repos/${{ github.repository }}/dispatches" \
+          #   -H "Accept: application/vnd.github+json" \
+          #   -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          #   -d "{\"event_type\":\"deploy-ecs\",\"client_payload\":{\"image_uri\":\"$image_uri\",\"tag\":\"$tag\",\"branch\":\"$branch\",\"sha\":\"$sha\"}}")
+          # [ "$resp" = "204" ] || (echo "ECS dispatch failed:" && cat /tmp/resp.txt && exit 1)
 
           # EC2
           resp2=$(curl -s -o /tmp/resp2.txt -w "%{http_code}" -X POST \
@@ -130,5 +130,5 @@ jobs:
           echo "- Tag:    \`${{ steps.tag.outputs.TAG }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Image:  \`${{ steps.build.outputs.IMAGE_URI }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Arches: \`linux/amd64, linux/arm64\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Sent:   \`repository_dispatch: deploy-ecs\`" >> $GITHUB_STEP_SUMMARY
+          # echo "- Sent:   \`repository_dispatch: deploy-ecs\`" >> $GITHUB_STEP_SUMMARY
           echo "- Sent:   \`repository_dispatch: deploy-ec2\`" >> $GITHUB_STEP_SUMMARY

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${COGNITO_ISSUER_URI:https://cognito-idp.ap-northeast-2.amazonaws.com/ap-northeast-2_xI18xw5er}
+          issuer-uri: ${COGNITO_ISSUER_URI:https://cognito-idp.ap-northeast-2.amazonaws.com/ap-northeast-2_4eeAfg0rE}
 
 # Spring Boot Actuator 설정
 management:
@@ -41,9 +41,9 @@ management:
 app:
   cognito:
     region: ${COGNITO_REGION:ap-northeast-2}
-    user-pool-id: ${COGNITO_USER_POOL_ID:ap-northeast-2_xI18xw5er}
-    client-id: ${COGNITO_CLIENT_ID:6l5ovdmof4vc5r2socegk41gt4}
-    user-info-uri: ${COGNITO_USER_INFO_URI:https://ap-northeast-2xi18xw5er.auth.ap-northeast-2.amazoncognito.com/oauth2/userInfo}
+    user-pool-id: ${COGNITO_USER_POOL_ID:ap-northeast-2_4eeAfg0rE}
+    client-id: ${COGNITO_CLIENT_ID:6ig8qk7cas8rajhqjcduvf6iqd}
+    user-info-uri: ${COGNITO_USER_INFO_URI:https://ap-northeast-24eeafg0re.auth.ap-northeast-2.amazoncognito.com/oauth2/userInfo}
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}
 
@@ -63,4 +63,3 @@ springdoc:
     tags-sorter: alpha
     operations-sorter: alpha
   packages-to-scan: com.nextcloudlab.kickytime
-  


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- Kickytime 백엔드를 현재 AWS 환경의 EC2에 배포할 수 있도록 GitHub Actions와 애플리케이션 설정을 갱신합니다.
- EC2에서 애플리케이션이 실제로 정상 기동됐는지 확인한 후 배포 성공 여부를 판단하도록 개선합니다.

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- 애플리케이션 실행 포트를 `8080`으로 통일
- 신규 Cognito 사용자 풀 ID, 앱 클라이언트 ID 및 사용자 정보 URI 적용
- ECR 기본 이미지 주소를 현재 AWS 계정의 `kickytime-repo`로 변경
- ECR 이미지 빌드 완료 후 ECS와 EC2를 동시에 배포하던 동작에서 ECS 배포를 임시 비활성화
- EC2 배포 시 SSM 명령 완료 상태와 응답 코드를 확인하도록 개선
- 컨테이너 기동 후 `/actuator/health`를 최대 120초 동안 확인하도록 구성
- 상태 확인 실패 시 컨테이너 로그를 출력하고 배포 작업이 실패하도록 처리
- 최초 빈 RDS의 테이블 생성을 위해 EC2 배포 환경에 `ddl-auto=update` 적용

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. `./gradlew test`를 실행하여 백엔드 테스트가 통과하는지 확인
2. GitHub Actions YAML 및 애플리케이션 YAML 파일이 정상적으로 파싱되는지 확인
3. main 브랜치 배포 시 ECR 이미지 생성 후 EC2 배포 워크플로가 실행되고 `/actuator/health`가 정상 응답하는지 확인

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: 없음