### PR TITLE
백엔드를 현재 AWS 환경의 EC2에 배포할 수 있도록 GitHub Actions와 애플리케이션 설정

### DIFF
--- a/.github/workflows/ec2.yml
+++ b/.github/workflows/ec2.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   AWS_REGION: ap-northeast-2
-  IMAGE: ${{ github.event.client_payload.image_uri || '077672914621.dkr.ecr.ap-northeast-2.amazonaws.com/kickytime-repo:latest' }}
+  IMAGE: ${{ github.event.client_payload.image_uri || '205366594951.dkr.ecr.ap-northeast-2.amazonaws.com/kickytime-repo:latest' }}
   TARGET_TAG_KEY: Role
   TARGET_TAG_VALUE: app
   PORT: "8080"
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo "Deploying image: $IMAGE"
           
-          aws ssm send-command \
+          COMMAND_ID=$(aws ssm send-command \
             --region $AWS_REGION \
             --document-name "AWS-RunShellScript" \
             --instance-ids $IDS_LIST \
@@ -66,9 +66,27 @@ jobs:
                 "  -e SPRING_DATASOURCE_URL=\"'${{ secrets.DB_URL }}'\" \\",
                 "  -e SPRING_DATASOURCE_USERNAME=\"'${{ secrets.DB_USERNAME }}'\" \\",
                 "  -e SPRING_DATASOURCE_PASSWORD=\"'${{ secrets.DB_PASSWORD }}'\" \\",
+                "  -e SPRING_JPA_HIBERNATE_DDL_AUTO=update \\",
                 "  \"'$IMAGE'\"",
-                "for i in $(seq 1 60); do curl -fsS http://127.0.0.1:'$PORT$HEALTH' && break || sleep 2; done"
+                "for i in $(seq 1 60); do curl -fsS http://127.0.0.1:'$PORT$HEALTH' && exit 0; sleep 2; done",
+                "docker logs --tail 200 kickytime || true",
+                "exit 1"
               ],
               "executionTimeout": ["1800"]
             }' \
-            --comment "Deploy $IMAGE"
+            --comment "Deploy $IMAGE" \
+            --query 'Command.CommandId' \
+            --output text)
+
+          for INSTANCE_ID in $IDS_LIST; do
+            aws ssm wait command-executed \
+              --region "$AWS_REGION" \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID"
+
+            aws ssm get-command-invocation \
+              --region "$AWS_REGION" \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query '{InstanceId:InstanceId,Status:Status,ResponseCode:ResponseCode,Output:StandardOutputContent,Error:StandardErrorContent}'
+          done

--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -107,13 +107,13 @@ jobs:
           branch="${{ github.ref_name }}"
           sha="${{ github.sha }}"
 
-          # ECS
-          resp=$(curl -s -o /tmp/resp.txt -w "%{http_code}" -X POST \
-            "https://api.github.com/repos/${{ github.repository }}/dispatches" \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -d "{\"event_type\":\"deploy-ecs\",\"client_payload\":{\"image_uri\":\"$image_uri\",\"tag\":\"$tag\",\"branch\":\"$branch\",\"sha\":\"$sha\"}}")
-          [ "$resp" = "204" ] || (echo "ECS dispatch failed:" && cat /tmp/resp.txt && exit 1)
+          # ECS 배포는 EC2 -> ECS 전환 단계에서 다시 활성화한다.
+          # resp=$(curl -s -o /tmp/resp.txt -w "%{http_code}" -X POST \
+          #   "https://api.github.com/repos/${{ github.repository }}/dispatches" \
+          #   -H "Accept: application/vnd.github+json" \
+          #   -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          #   -d "{\"event_type\":\"deploy-ecs\",\"client_payload\":{\"image_uri\":\"$image_uri\",\"tag\":\"$tag\",\"branch\":\"$branch\",\"sha\":\"$sha\"}}")
+          # [ "$resp" = "204" ] || (echo "ECS dispatch failed:" && cat /tmp/resp.txt && exit 1)
 
           # EC2
           resp2=$(curl -s -o /tmp/resp2.txt -w "%{http_code}" -X POST \
@@ -130,5 +130,5 @@ jobs:
           echo "- Tag:    \`${{ steps.tag.outputs.TAG }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Image:  \`${{ steps.build.outputs.IMAGE_URI }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Arches: \`linux/amd64, linux/arm64\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Sent:   \`repository_dispatch: deploy-ecs\`" >> $GITHUB_STEP_SUMMARY
+          # echo "- Sent:   \`repository_dispatch: deploy-ecs\`" >> $GITHUB_STEP_SUMMARY
           echo "- Sent:   \`repository_dispatch: deploy-ec2\`" >> $GITHUB_STEP_SUMMARY

--- a/src/main/java/com/nextcloudlab/kickytime/match/dto/MatchCreateRequestDto.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/dto/MatchCreateRequestDto.java
@@ -2,18 +2,5 @@ package com.nextcloudlab.kickytime.match.dto;
 
 import java.time.LocalDateTime;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-public class MatchCreateRequestDto {
-    private Long createdBy;
-    private LocalDateTime matchDateTime;
-    private String location;
-    private Integer maxPlayers;
-}
+public record MatchCreateRequestDto(
+        Long createdBy, LocalDateTime matchDateTime, String location, Integer maxPlayers) {}

--- a/src/main/java/com/nextcloudlab/kickytime/match/dto/MatchResponseDto.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/dto/MatchResponseDto.java
@@ -6,45 +6,28 @@ import com.nextcloudlab.kickytime.match.entity.Match;
 import com.nextcloudlab.kickytime.match.entity.MatchStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
 @Schema(description = "경기 개설 요청 데이터")
-public class MatchResponseDto {
-
-    @Schema(description = "경기 ID", example = "1", required = true)
-    private Long id;
-
-    @Schema(
-            description = "경기 상태",
-            example = "OPEN, FULL, CLOSED, CANCELED",
-            required = false,
-            defaultValue = "OPEN")
-    private MatchStatus matchStatus;
-
-    @Schema(description = "경기 일시", example = "2025-08-14T19:00:00", required = true)
-    private LocalDateTime matchDateTime;
-
-    @Schema(description = "경기 장소", example = "서울특별시 축구장", required = true)
-    private String location;
-
-    @Schema(description = "최대 참가자 수", example = "10", required = true)
-    private Integer maxPlayers;
-
-    private Integer currentParticipants;
-
-    public MatchResponseDto(Match match) {
-        this.id = match.getId();
-        this.matchStatus = match.getMatchStatus();
-        this.matchDateTime = match.getMatchDateTime();
-        this.location = match.getLocation();
-        this.maxPlayers = match.getMaxPlayers();
-        this.currentParticipants = match.getCurrentParticipantCount();
+public record MatchResponseDto(
+        @Schema(description = "경기 ID", example = "1", required = true) Long id,
+        @Schema(
+                        description = "경기 상태",
+                        example = "OPEN, FULL, CLOSED, CANCELED",
+                        required = false,
+                        defaultValue = "OPEN")
+                MatchStatus matchStatus,
+        @Schema(description = "경기 일시", example = "2025-08-14T19:00:00", required = true)
+                LocalDateTime matchDateTime,
+        @Schema(description = "경기 장소", example = "서울특별시 축구장", required = true) String location,
+        @Schema(description = "최대 참가자 수", example = "10", required = true) Integer maxPlayers,
+        Integer currentParticipants) {
+    public static MatchResponseDto from(Match match) {
+        return new MatchResponseDto(
+                match.getId(),
+                match.getMatchStatus(),
+                match.getMatchDateTime(),
+                match.getLocation(),
+                match.getMaxPlayers(),
+                match.getCurrentParticipantCount());
     }
 }

--- a/src/main/java/com/nextcloudlab/kickytime/match/entity/Match.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/entity/Match.java
@@ -4,8 +4,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import com.nextcloudlab.kickytime.common.entity.BaseEntity;
 import com.nextcloudlab.kickytime.user.entity.User;
 
@@ -21,7 +19,6 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @Table(name = "matches")
 public class Match extends BaseEntity {
     @Id
@@ -32,7 +29,6 @@ public class Match extends BaseEntity {
     @Column(nullable = false)
     private MatchStatus matchStatus;
 
-    //    @Future(message = "경기 일시는 현재보다 미래여야 합니다.")
     @Column(nullable = false)
     private LocalDateTime matchDateTime;
 

--- a/src/main/java/com/nextcloudlab/kickytime/match/entity/MatchStatus.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/entity/MatchStatus.java
@@ -4,5 +4,5 @@ public enum MatchStatus {
     OPEN, // 모집 중 (정원 미달)
     FULL, // 모집 마감 (정원 충족)
     CLOSED, // 경기 종료
-    CANCELLED // 경기 취소
+    CANCELED // 경기 취소
 }

--- a/src/main/java/com/nextcloudlab/kickytime/match/service/MatchParticipantService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/service/MatchParticipantService.java
@@ -47,6 +47,6 @@ public class MatchParticipantService {
 
     private boolean isCompleted(MyMatchesResponse.MatchInfo match) {
         return match.matchStatus() == MatchStatus.CLOSED
-                || match.matchStatus() == MatchStatus.CANCELLED;
+                || match.matchStatus() == MatchStatus.CANCELED;
     }
 }

--- a/src/main/java/com/nextcloudlab/kickytime/match/service/MatchParticipantService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/service/MatchParticipantService.java
@@ -13,11 +13,11 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class MatchParticipantService {
 
     private final MatchParticipantRepository matchParticipantRepository;
 
+    @Transactional(readOnly = true)
     public MyMatchesResponse getMyParticipant(String cognitoSub) {
 
         List<MyMatchesResponse.MatchInfo> matches =

--- a/src/main/java/com/nextcloudlab/kickytime/match/service/MatchService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/service/MatchService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.nextcloudlab.kickytime.match.dto.MatchCreateRequestDto;
 import com.nextcloudlab.kickytime.match.dto.MatchResponseDto;
@@ -17,7 +18,6 @@ import com.nextcloudlab.kickytime.match.repository.MatchRepository;
 import com.nextcloudlab.kickytime.user.entity.RoleEnum;
 import com.nextcloudlab.kickytime.user.entity.User;
 import com.nextcloudlab.kickytime.user.repository.UserRepository;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MatchService {

--- a/src/main/java/com/nextcloudlab/kickytime/match/service/MatchService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/service/MatchService.java
@@ -17,11 +17,9 @@ import com.nextcloudlab.kickytime.match.repository.MatchRepository;
 import com.nextcloudlab.kickytime.user.entity.RoleEnum;
 import com.nextcloudlab.kickytime.user.entity.User;
 import com.nextcloudlab.kickytime.user.repository.UserRepository;
-
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 public class MatchService {
 
     private final MatchRepository matchRepository;
@@ -38,7 +36,7 @@ public class MatchService {
     }
 
     // 전체 경기 목록 조회
-    @Transactional()
+    @Transactional(readOnly = true)
     public List<MatchResponseDto> getAllMatches() {
         List<Match> matches = matchRepository.findAllByOrderByMatchDateTimeDesc();
 
@@ -46,6 +44,7 @@ public class MatchService {
     }
 
     // 경기 개설
+    @Transactional
     public void createMatch(MatchCreateRequestDto requestDto) {
         User user =
                 userRepository
@@ -67,6 +66,7 @@ public class MatchService {
     }
 
     // 경기 참여 신청
+    @Transactional
     public void joinMatch(Long matchId, String cognitoSub) {
         Match match =
                 matchRepository
@@ -105,6 +105,7 @@ public class MatchService {
     }
 
     // 경기 참여 취소(일반회원)
+    @Transactional
     public void leaveMatch(Long matchId, String cognitoSub) {
         Match match =
                 matchRepository
@@ -125,6 +126,7 @@ public class MatchService {
     }
 
     // 매치 삭제 기능
+    @Transactional
     public void deleteMatchById(Long matchId) {
         if (!matchRepository.existsById(matchId)) {
             throw new IllegalArgumentException("해당 매치를 찾을 수 없습니다.");

--- a/src/main/java/com/nextcloudlab/kickytime/match/service/MatchService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/match/service/MatchService.java
@@ -42,14 +42,14 @@ public class MatchService {
     public List<MatchResponseDto> getAllMatches() {
         List<Match> matches = matchRepository.findAllByOrderByMatchDateTimeDesc();
 
-        return matches.stream().map(MatchResponseDto::new).collect(Collectors.toList());
+        return matches.stream().map(MatchResponseDto::from).collect(Collectors.toList());
     }
 
     // 경기 개설
     public void createMatch(MatchCreateRequestDto requestDto) {
         User user =
                 userRepository
-                        .findById(requestDto.getCreatedBy())
+                        .findById(requestDto.createdBy())
                         .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
         if (user.getRole() != RoleEnum.ADMIN) {
@@ -58,9 +58,9 @@ public class MatchService {
 
         Match match = new Match();
         match.setMatchStatus(MatchStatus.OPEN);
-        match.setMatchDateTime(requestDto.getMatchDateTime());
-        match.setLocation(requestDto.getLocation());
-        match.setMaxPlayers(requestDto.getMaxPlayers());
+        match.setMatchDateTime(requestDto.matchDateTime());
+        match.setLocation(requestDto.location());
+        match.setMaxPlayers(requestDto.maxPlayers());
         match.setCreatedBy(user);
 
         matchRepository.save(match);

--- a/src/main/java/com/nextcloudlab/kickytime/user/service/CognitoBackfillService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/service/CognitoBackfillService.java
@@ -8,9 +8,9 @@ import org.springframework.stereotype.Service;
 import com.nextcloudlab.kickytime.user.entity.User;
 import com.nextcloudlab.kickytime.user.repository.UserRepository;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.*;
 
@@ -24,10 +24,12 @@ public class CognitoBackfillService {
     @Value("${app.cognito.user-pool-id}")
     private String userPoolId;
 
+    @Transactional(readOnly = true)
     public BackfillReport backfillAllUsers() {
         return backfillReport();
     }
 
+    @Transactional
     public BackfillReport backfillReport() {
         int processed = 0, created = 0, updated = 0;
 

--- a/src/main/java/com/nextcloudlab/kickytime/user/service/CognitoBackfillService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/service/CognitoBackfillService.java
@@ -4,13 +4,13 @@ import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.nextcloudlab.kickytime.user.entity.User;
 import com.nextcloudlab.kickytime.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.*;
 

--- a/src/main/java/com/nextcloudlab/kickytime/user/service/UserService.java
+++ b/src/main/java/com/nextcloudlab/kickytime/user/service/UserService.java
@@ -2,13 +2,13 @@ package com.nextcloudlab.kickytime.user.service;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.nextcloudlab.kickytime.user.dto.UserDto;
 import com.nextcloudlab.kickytime.user.entity.User;
 import com.nextcloudlab.kickytime.user.repository.UserRepository;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -45,7 +45,7 @@ public class UserService {
                         });
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public UserDto getByCognitoSub(String cognitoSub) {
         User me =
                 userRepository

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${COGNITO_ISSUER_URI:https://cognito-idp.ap-northeast-2.amazonaws.com/ap-northeast-2_xI18xw5er}
+          issuer-uri: ${COGNITO_ISSUER_URI:https://cognito-idp.ap-northeast-2.amazonaws.com/ap-northeast-2_4eeAfg0rE}
 
 # Spring Boot Actuator 설정
 management:
@@ -41,9 +41,9 @@ management:
 app:
   cognito:
     region: ${COGNITO_REGION:ap-northeast-2}
-    user-pool-id: ${COGNITO_USER_POOL_ID:ap-northeast-2_xI18xw5er}
-    client-id: ${COGNITO_CLIENT_ID:6l5ovdmof4vc5r2socegk41gt4}
-    user-info-uri: ${COGNITO_USER_INFO_URI:https://ap-northeast-2xi18xw5er.auth.ap-northeast-2.amazoncognito.com/oauth2/userInfo}
+    user-pool-id: ${COGNITO_USER_POOL_ID:ap-northeast-2_4eeAfg0rE}
+    client-id: ${COGNITO_CLIENT_ID:6ig8qk7cas8rajhqjcduvf6iqd}
+    user-info-uri: ${COGNITO_USER_INFO_URI:https://ap-northeast-24eeafg0re.auth.ap-northeast-2.amazoncognito.com/oauth2/userInfo}
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}
 
@@ -63,4 +63,3 @@ springdoc:
     tags-sorter: alpha
     operations-sorter: alpha
   packages-to-scan: com.nextcloudlab.kickytime
-  

--- a/src/test/java/com/nextcloudlab/kickytime/match/service/MatchParticipantServiceTest.java
+++ b/src/test/java/com/nextcloudlab/kickytime/match/service/MatchParticipantServiceTest.java
@@ -42,7 +42,7 @@ class MatchParticipantServiceTest {
                         createMatchInfo(1L, MatchStatus.OPEN),
                         createMatchInfo(2L, MatchStatus.FULL),
                         createMatchInfo(3L, MatchStatus.CLOSED),
-                        createMatchInfo(4L, MatchStatus.CANCELLED),
+                        createMatchInfo(4L, MatchStatus.CANCELED),
                         createMatchInfo(5L, MatchStatus.OPEN),
                         createMatchInfo(6L, MatchStatus.CLOSED));
 
@@ -51,7 +51,7 @@ class MatchParticipantServiceTest {
                 Arrays.asList(
                         createMatchInfoWithDetails(3L, MatchStatus.OPEN, "서울 OO풋살장 A코트", 10),
                         createMatchInfoWithDetails(4L, MatchStatus.CLOSED, "부산 XX풋살파크 B코트", 8),
-                        createMatchInfoWithDetails(5L, MatchStatus.CANCELLED, "인천 YY스타디움 C코트", 12));
+                        createMatchInfoWithDetails(5L, MatchStatus.CANCELED, "인천 YY스타디움 C코트", 12));
     }
 
     @Test
@@ -71,7 +71,7 @@ class MatchParticipantServiceTest {
         MyMatchesResponse.Summary summary = result.summary();
         assertThat(summary.totalCount()).isEqualTo(6L);
         assertThat(summary.upcomingCount()).isEqualTo(3L); // OPEN(2) + FULL(1)
-        assertThat(summary.completedCount()).isEqualTo(3L); // CLOSED(2) + CANCELLED(1)
+        assertThat(summary.completedCount()).isEqualTo(3L); // CLOSED(2) + CANCELED(1)
     }
 
     @Test
@@ -135,15 +135,15 @@ class MatchParticipantServiceTest {
     }
 
     @Test
-    @DisplayName("CANCELLED 상태만 있는 경우")
-    void getMyParticipantWithOnlyCancelledMatchesShouldReturnCorrectCounts() {
+    @DisplayName("CANCELED 상태만 있는 경우")
+    void getMyParticipantWithOnlyCanceledMatchesShouldReturnCorrectCounts() {
         // given
-        List<MyMatchesResponse.MatchInfo> cancelledMatches =
+        List<MyMatchesResponse.MatchInfo> canceledMatches =
                 Arrays.asList(
-                        createMatchInfo(1L, MatchStatus.CANCELLED),
-                        createMatchInfo(2L, MatchStatus.CANCELLED));
+                        createMatchInfo(1L, MatchStatus.CANCELED),
+                        createMatchInfo(2L, MatchStatus.CANCELED));
         when(matchParticipantRepository.findMatchParticipantByUserId(testCognitoSub))
-                .thenReturn(cancelledMatches);
+                .thenReturn(canceledMatches);
 
         // when
         MyMatchesResponse result = matchParticipantService.getMyParticipant(testCognitoSub);
@@ -208,7 +208,7 @@ class MatchParticipantServiceTest {
     @Test
     @DisplayName("실제 데이터 시나리오 - SQL 기반 매치 참가자 조회")
     void getMyParticipantRealWorldScenarioShouldReturnCorrectCounts() {
-        // given - user_id 3이 참가한 매치들 (OPEN, CLOSED, CANCELLED)
+        // given - user_id 3이 참가한 매치들 (OPEN, CLOSED, CANCELED)
         when(matchParticipantRepository.findMatchParticipantByUserId(testCognitoSub))
                 .thenReturn(realWorldMatches);
 
@@ -222,7 +222,7 @@ class MatchParticipantServiceTest {
         MyMatchesResponse.Summary summary = result.summary();
         assertThat(summary.totalCount()).isEqualTo(3L);
         assertThat(summary.upcomingCount()).isEqualTo(1L); // OPEN(1)
-        assertThat(summary.completedCount()).isEqualTo(2L); // CLOSED(1) + CANCELLED(1)
+        assertThat(summary.completedCount()).isEqualTo(2L); // CLOSED(1) + CANCELED(1)
 
         // 매치 상세 정보 검증
         List<MyMatchesResponse.MatchInfo> matches = result.matches();
@@ -240,7 +240,7 @@ class MatchParticipantServiceTest {
                         createMatchInfoWithDetails(1L, MatchStatus.OPEN, "서울 OO풋살장 A코트", 10),
                         createMatchInfoWithDetails(2L, MatchStatus.FULL, "서울 OO풋살장 B코트", 8),
                         createMatchInfoWithDetails(3L, MatchStatus.CLOSED, "부산 XX풋살파크 A코트", 12),
-                        createMatchInfoWithDetails(4L, MatchStatus.CANCELLED, "인천 YY스타디움 C코트", 16));
+                        createMatchInfoWithDetails(4L, MatchStatus.CANCELED, "인천 YY스타디움 C코트", 16));
 
         when(matchParticipantRepository.findMatchParticipantByUserId(testCognitoSub))
                 .thenReturn(locationMatches);
@@ -251,7 +251,7 @@ class MatchParticipantServiceTest {
         // then
         assertThat(result.summary().totalCount()).isEqualTo(4L);
         assertThat(result.summary().upcomingCount()).isEqualTo(2L); // OPEN + FULL
-        assertThat(result.summary().completedCount()).isEqualTo(2L); // CLOSED + CANCELLED
+        assertThat(result.summary().completedCount()).isEqualTo(2L); // CLOSED + CANCELED
 
         // 서울 지역 매치가 2개인지 확인
         long seoulMatches =
@@ -286,13 +286,13 @@ class MatchParticipantServiceTest {
     @Test
     @DisplayName("시간 기반 매치 상태 검증 - 과거/미래 매치")
     void getMyParticipantTimeBasedMatchesShouldProcessCorrectly() {
-        // given - 시간 관련 특성을 가진 매치들 (과거 날짜는 CLOSED/CANCELLED, 미래 날짜는 OPEN/FULL)
+        // given - 시간 관련 특성을 가진 매치들 (과거 날짜는 CLOSED/CANCELED, 미래 날짜는 OPEN/FULL)
         List<MyMatchesResponse.MatchInfo> timeBasedMatches =
                 Arrays.asList(
                         createMatchInfoWithDetails(
                                 1L, MatchStatus.CLOSED, "과거 매치 1", 10), // 과거 - 종료됨
                         createMatchInfoWithDetails(
-                                2L, MatchStatus.CANCELLED, "취소된 매치", 8), // 과거 - 취소됨
+                                2L, MatchStatus.CANCELED, "취소된 매치", 8), // 과거 - 취소됨
                         createMatchInfoWithDetails(3L, MatchStatus.OPEN, "미래 매치 1", 12), // 미래 - 모집중
                         createMatchInfoWithDetails(
                                 4L, MatchStatus.FULL, "미래 매치 2", 10), // 미래 - 모집완료
@@ -308,7 +308,7 @@ class MatchParticipantServiceTest {
         // then
         assertThat(result.summary().totalCount()).isEqualTo(5L);
         assertThat(result.summary().upcomingCount()).isEqualTo(3L); // OPEN(2) + FULL(1)
-        assertThat(result.summary().completedCount()).isEqualTo(2L); // CLOSED(1) + CANCELLED(1)
+        assertThat(result.summary().completedCount()).isEqualTo(2L); // CLOSED(1) + CANCELED(1)
     }
 
     // 테스트 헬퍼 메서드
@@ -332,7 +332,7 @@ class MatchParticipantServiceTest {
         LocalDateTime matchTime =
                 switch (status) {
                     case OPEN, FULL -> baseTime.plusDays(2); // 미래 매치
-                    case CLOSED, CANCELLED -> baseTime.minusDays(1); // 과거 매치
+                    case CLOSED, CANCELED -> baseTime.minusDays(1); // 과거 매치
                 };
 
         return new MyMatchesResponse.MatchInfo(

--- a/src/test/java/com/nextcloudlab/kickytime/match/service/MatchServiceTest.java
+++ b/src/test/java/com/nextcloudlab/kickytime/match/service/MatchServiceTest.java
@@ -70,11 +70,8 @@ class MatchServiceTest {
         testMatch.setCreatedBy(adminUser);
 
         // 경기 생성 요청 DTO
-        createRequestDto = new MatchCreateRequestDto();
-        createRequestDto.setCreatedBy(1L);
-        createRequestDto.setMatchDateTime(LocalDateTime.now().plusDays(1));
-        createRequestDto.setLocation("서울 강남구");
-        createRequestDto.setMaxPlayers(10);
+        createRequestDto =
+                new MatchCreateRequestDto(1L, LocalDateTime.now().plusDays(1), "서울 강남구", 10);
     }
 
     @Test
@@ -89,8 +86,8 @@ class MatchServiceTest {
 
         // then
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getId()).isEqualTo(testMatch.getId());
-        assertThat(result.get(0).getLocation()).isEqualTo(testMatch.getLocation());
+        assertThat(result.get(0).id()).isEqualTo(testMatch.getId());
+        assertThat(result.get(0).location()).isEqualTo(testMatch.getLocation());
         verify(matchRepository).findAllByOrderByMatchDateTimeDesc();
     }
 
@@ -124,11 +121,15 @@ class MatchServiceTest {
     @Test
     @DisplayName("경기 개설 - 관리자 권한 없음 예외")
     void createMatchNotAdminUser() {
-        // given
-        createRequestDto.setCreatedBy(2L);
+        // createRequestDto는 setter가 없으므로 새로운 인스턴스 생성
+        createRequestDto =
+                new MatchCreateRequestDto(
+                        2L,
+                        createRequestDto.matchDateTime(),
+                        createRequestDto.location(),
+                        createRequestDto.maxPlayers());
         given(userRepository.findById(2L)).willReturn(Optional.of(regularUser));
 
-        // when & then
         assertThatThrownBy(() -> matchService.createMatch(createRequestDto))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("관리자 권한이 있는 사용자만 경기를 개설할 수 있습니다.");


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- Kickytime 백엔드를 현재 AWS 환경의 EC2에 배포할 수 있도록 GitHub Actions와 애플리케이션 설정을 갱신합니다.
- EC2에서 애플리케이션이 실제로 정상 기동됐는지 확인한 후 배포 성공 여부를 판단하도록 개선합니다.

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- 애플리케이션 실행 포트를 `8080`으로 통일
- 신규 Cognito 사용자 풀 ID, 앱 클라이언트 ID 및 사용자 정보 URI 적용
- ECR 기본 이미지 주소를 현재 AWS 계정의 `kickytime-repo`로 변경
- ECR 이미지 빌드 완료 후 ECS와 EC2를 동시에 배포하던 동작에서 ECS 배포를 임시 비활성화
- EC2 배포 시 SSM 명령 완료 상태와 응답 코드를 확인하도록 개선
- 컨테이너 기동 후 `/actuator/health`를 최대 120초 동안 확인하도록 구성
- 상태 확인 실패 시 컨테이너 로그를 출력하고 배포 작업이 실패하도록 처리
- 최초 빈 RDS의 테이블 생성을 위해 EC2 배포 환경에 `ddl-auto=update` 적용

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. `./gradlew test`를 실행하여 백엔드 테스트가 통과하는지 확인
2. GitHub Actions YAML 및 애플리케이션 YAML 파일이 정상적으로 파싱되는지 확인
3. main 브랜치 배포 시 ECR 이미지 생성 후 EC2 배포 워크플로가 실행되고 `/actuator/health`가 정상 응답하는지 확인

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: 없음