### PR TITLE
🔧 config(deploy): EC2 배포 및 CloudFront CORS 설정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -11,4 +11,4 @@ spring:
 
 app:
   cors:
-    allowed-origins: "https://kickytime.nextcloudlab.com"
+    allowed-origins: "https://d2hk3a4qv3wwww.cloudfront.net"


### PR DESCRIPTION
## 📌 PR 개요
- EC2 기반 백엔드 재배포 설정을 반영하고, 현재 CloudFront 배포 도메인에서 인증 API를 호출할 수 있도록 운영 CORS 설정을 갱신합니다.

## 🔍 변경 사항
- EC2/SSM/ECR 배포 설정 및 Cognito 구성 갱신
- 운영 서버 포트를 8080으로 통일
- 운영 CORS 허용 출처를 `https://d2hk3a4qv3wwww.cloudfront.net`으로 변경
- Cognito 로그인 후 `POST /api/users/signin-up`이 CORS 403으로 차단되는 문제 해결

## 🧪 테스트 방법
1. `./gradlew test`를 실행합니다.
2. GitHub Actions를 통해 새 백엔드 이미지를 EC2 인스턴스에 배포합니다.
3. CloudFront 도메인에서 Cognito 로그인 후 `POST /api/users/signin-up` 및 `GET /api/users/me` 응답을 확인합니다.

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션(Checkstyle 등)을 통과함
- [x] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 📎 참고 이슈
Ref: 없음
