### PR TITLE
Kickytime AWS 재배포를 위한 백엔드 운영 설정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -11,4 +11,4 @@ spring:
 
 app:
   cors:
-    allowed-origins: "https://kickytime.nextcloudlab.com"
+    allowed-origins: "https://d2hk3a4qv3wwww.cloudfront.net"


### PR DESCRIPTION
## 📌 PR 개요
- Kickytime AWS 재배포를 위한 백엔드 운영 설정을 `main` 브랜치에 반영합니다.

## 🔍 변경 사항
- EC2·SSM·ECR 기반 백엔드 배포 설정 반영
- 운영 서버 포트를 8080으로 통일
- Cognito 운영 환경 설정 갱신
- CloudFront 배포 도메인 CORS 허용

## 🧪 테스트 방법
1. GitHub Actions 배포 성공 여부를 확인합니다.
2. CloudFront에서 Cognito 로그인을 진행합니다.
3. 사용자 생성 및 조회 API가 정상 동작하는지 확인합니다.

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 백엔드 테스트를 통과함
- [x] 운영 환경 설정을 확인함
- [ ] 배포 후 로그인 종단 테스트 완료

## 📎 참고 이슈
Ref: 없음