### PR TITLE
🔧 config(deploy): ECS 블루그린 배포 워크플로 전환

### DIFF
--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -101,21 +101,12 @@ jobs:
           branch="${{ github.ref_name }}"
           sha="${{ github.sha }}"
 
-          # ECS 배포는 EC2 -> ECS 전환 단계에서 다시 활성화한다.
-          # resp=$(curl -s -o /tmp/resp.txt -w "%{http_code}" -X POST \
-          #   "https://api.github.com/repos/${{ github.repository }}/dispatches" \
-          #   -H "Accept: application/vnd.github+json" \
-          #   -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          #   -d "{\"event_type\":\"deploy-ecs\",\"client_payload\":{\"image_uri\":\"$image_uri\",\"tag\":\"$tag\",\"branch\":\"$branch\",\"sha\":\"$sha\"}}")
-          # [ "$resp" = "204" ] || (echo "ECS dispatch failed:" && cat /tmp/resp.txt && exit 1)
-
-          # EC2
-          resp2=$(curl -s -o /tmp/resp2.txt -w "%{http_code}" -X POST \
+          resp=$(curl -s -o /tmp/resp.txt -w "%{http_code}" -X POST \
             "https://api.github.com/repos/${{ github.repository }}/dispatches" \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -d "{\"event_type\":\"deploy-ec2\",\"client_payload\":{\"image_uri\":\"$image_uri\",\"tag\":\"$tag\",\"branch\":\"$branch\",\"sha\":\"$sha\"}}")
-          [ "$resp2" = "204" ] || (echo "EC2 dispatch failed:" && cat /tmp/resp2.txt && exit 1)
+            -d "{\"event_type\":\"deploy-ecs\",\"client_payload\":{\"image_uri\":\"$image_uri\",\"tag\":\"$tag\",\"branch\":\"$branch\",\"sha\":\"$sha\"}}")
+          [ "$resp" = "204" ] || (echo "ECS dispatch failed:" && cat /tmp/resp.txt && exit 1)
 
       - name: Summary
         run: |
@@ -124,5 +115,4 @@ jobs:
           echo "- Tag:    \`${{ steps.tag.outputs.TAG }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Image:  \`${{ steps.build.outputs.IMAGE_URI }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Arch:   \`linux/arm64\`" >> $GITHUB_STEP_SUMMARY
-          # echo "- Sent:   \`repository_dispatch: deploy-ecs\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Sent:   \`repository_dispatch: deploy-ec2\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Sent:   \`repository_dispatch: deploy-ecs\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -16,9 +16,9 @@ env:
   AWS_REGION: ap-northeast-2
   ECR_REPOSITORY: kickytime-repo
   ECS_CLUSTER: kickytime-cluster
-  ECS_SERVICE: kickytime-task-service
+  ECS_SERVICE: kickytime-service
   TASK_FAMILY: kickytime-task
-  CONTAINER_NAME: kickytime-ecr
+  CONTAINER_NAME: kickytime
 
 jobs:
   deploy:
@@ -85,7 +85,7 @@ jobs:
             --output text)
           echo "TASK_DEF_ARN=$NEW_TD_ARN" >> $GITHUB_OUTPUT
 
-      - name: Update service (rolling deployment)
+      - name: Update service (ECS blue/green deployment)
         if: steps.gate.outputs.GO == 'true'
         run: |
           aws ecs update-service \


### PR DESCRIPTION
## 📌 PR 개요

- EC2 배포에서 ECS Blue/Green 배포 방식으로 GitHub Actions 워크플로를 전환합니다.

## 🔍 변경 사항

- ECS 서비스 이름을 `kickytime-service`로 수정
- 태스크 정의 컨테이너 이름을 `kickytime`으로 수정
- ECR 이미지 빌드 완료 후 `deploy-ecs` 이벤트가 실행되도록 변경
- EC2 SSM 배포 호출 제거
- ECS 서비스 업데이트 단계 명칭을 Blue/Green 배포 방식에 맞게 수정

## 🧪 테스트 방법

1. 변경 사항을 develop 및 main에 병합합니다.
2. ECR 워크플로에서 ARM64 이미지 빌드와 푸시 성공 여부를 확인합니다.
3. 이어서 ECS 배포 워크플로가 실행되는지 확인합니다.
4. ECS 서비스에서 새 태스크 정의 배포와 Blue/Green 전환 성공 여부를 확인합니다.
5. CloudFront에서 로그인과 주요 API를 종단 테스트합니다.

## ✅ 체크리스트

- [x] 워크플로 설정값을 실제 ECS 리소스와 일치시킴
- [x] 기존 애플리케이션 코드를 변경하지 않음
- [x] EC2 배포 이벤트가 중복 호출되지 않도록 처리함
- [ ] GitHub Actions ECS 배포 성공 확인
- [ ] 배포 후 종단 테스트 완료

## 📎 참고 이슈

Ref: #