### PR TITLE
main에 먼저 반영된 ECS Blue/Green 배포 워크플로 변경을 develop 브랜치에 역병합

### DIFF
--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -101,21 +101,12 @@ jobs:
           branch="${{ github.ref_name }}"
           sha="${{ github.sha }}"
 
-          # ECS 배포는 EC2 -> ECS 전환 단계에서 다시 활성화한다.
-          # resp=$(curl -s -o /tmp/resp.txt -w "%{http_code}" -X POST \
-          #   "https://api.github.com/repos/${{ github.repository }}/dispatches" \
-          #   -H "Accept: application/vnd.github+json" \
-          #   -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          #   -d "{\"event_type\":\"deploy-ecs\",\"client_payload\":{\"image_uri\":\"$image_uri\",\"tag\":\"$tag\",\"branch\":\"$branch\",\"sha\":\"$sha\"}}")
-          # [ "$resp" = "204" ] || (echo "ECS dispatch failed:" && cat /tmp/resp.txt && exit 1)
-
-          # EC2
-          resp2=$(curl -s -o /tmp/resp2.txt -w "%{http_code}" -X POST \
+          resp=$(curl -s -o /tmp/resp.txt -w "%{http_code}" -X POST \
             "https://api.github.com/repos/${{ github.repository }}/dispatches" \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -d "{\"event_type\":\"deploy-ec2\",\"client_payload\":{\"image_uri\":\"$image_uri\",\"tag\":\"$tag\",\"branch\":\"$branch\",\"sha\":\"$sha\"}}")
-          [ "$resp2" = "204" ] || (echo "EC2 dispatch failed:" && cat /tmp/resp2.txt && exit 1)
+            -d "{\"event_type\":\"deploy-ecs\",\"client_payload\":{\"image_uri\":\"$image_uri\",\"tag\":\"$tag\",\"branch\":\"$branch\",\"sha\":\"$sha\"}}")
+          [ "$resp" = "204" ] || (echo "ECS dispatch failed:" && cat /tmp/resp.txt && exit 1)
 
       - name: Summary
         run: |
@@ -124,5 +115,4 @@ jobs:
           echo "- Tag:    \`${{ steps.tag.outputs.TAG }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Image:  \`${{ steps.build.outputs.IMAGE_URI }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Arch:   \`linux/arm64\`" >> $GITHUB_STEP_SUMMARY
-          # echo "- Sent:   \`repository_dispatch: deploy-ecs\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Sent:   \`repository_dispatch: deploy-ec2\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Sent:   \`repository_dispatch: deploy-ecs\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -16,9 +16,9 @@ env:
   AWS_REGION: ap-northeast-2
   ECR_REPOSITORY: kickytime-repo
   ECS_CLUSTER: kickytime-cluster
-  ECS_SERVICE: kickytime-task-service
+  ECS_SERVICE: kickytime-service
   TASK_FAMILY: kickytime-task
-  CONTAINER_NAME: kickytime-ecr
+  CONTAINER_NAME: kickytime
 
 jobs:
   deploy:
@@ -85,7 +85,7 @@ jobs:
             --output text)
           echo "TASK_DEF_ARN=$NEW_TD_ARN" >> $GITHUB_OUTPUT
 
-      - name: Update service (rolling deployment)
+      - name: Update service (ECS blue/green deployment)
         if: steps.gate.outputs.GO == 'true'
         run: |
           aws ecs update-service \


### PR DESCRIPTION
## 📌 PR 개요

- main에 먼저 반영된 ECS Blue/Green 배포 워크플로 변경을 develop 브랜치에 역병합하여 브랜치 간 차이를 해소합니다.

## 🔍 변경 사항

- ECS 서비스 이름을 `kickytime-service`로 반영
- 태스크 컨테이너 이름을 `kickytime`으로 반영
- ECR 빌드 이후 ECS 배포 워크플로가 실행되도록 변경
- main과 develop의 배포 설정 동기화

## 🧪 테스트 방법

1. PR 병합 후 main과 develop의 워크플로 파일을 비교합니다.
2. `.github/workflows/ecr.yml`과 `.github/workflows/ecs.yml`이 동일한지 확인합니다.
3. 기존 CI 성공 여부를 확인합니다.

## ✅ 체크리스트

- [x] main에 반영된 변경만 develop으로 동기화함
- [x] 애플리케이션 코드는 변경하지 않음
- [x] 기존 ECS 배포 설정을 유지함
- [ ] develop 병합 완료

## 📎 참고 이슈

Ref: #90