### PR TITLE
ECS Blue/Green 배포가 롤백됐음에도 GitHub Actions가 성공으로 판단하던 문제를 수정합니다.

### DIFF
--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -59,11 +59,23 @@ jobs:
         id: ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Describe current Task Definition
+      - name: Describe Task Definition currently serving production
         if: steps.gate.outputs.GO == 'true'
         run: |
+          CURRENT_TD_ARN=$(aws ecs describe-services \
+            --cluster "${{ env.ECS_CLUSTER }}" \
+            --services "${{ env.ECS_SERVICE }}" \
+            --query 'services[0].taskDefinition' \
+            --output text)
+
+          if [ -z "$CURRENT_TD_ARN" ] || [ "$CURRENT_TD_ARN" = "None" ]; then
+            echo "Unable to resolve the task definition currently used by the ECS service."
+            exit 1
+          fi
+
+          echo "Using production task definition as deployment base: $CURRENT_TD_ARN"
           aws ecs describe-task-definition \
-            --task-definition "${{ env.TASK_FAMILY }}" \
+            --task-definition "$CURRENT_TD_ARN" \
             --query 'taskDefinition' > td.json
 
       - name: Patch image & ensure ARM64 platform
@@ -96,23 +108,35 @@ jobs:
 
       - name: Wait for deployment (timeout 10m)
         if: steps.gate.outputs.GO == 'true'
-        id: wait
-        continue-on-error: true
         run: |
           timeout 600 aws ecs wait services-stable \
             --cluster "${{ env.ECS_CLUSTER }}" \
-            --services "${{ env.ECS_SERVICE }}" || echo "WAIT_FAILED=true" >> $GITHUB_OUTPUT
+            --services "${{ env.ECS_SERVICE }}"
+
+      - name: Verify the new Task Definition is serving production
+        if: steps.gate.outputs.GO == 'true'
+        run: |
+          EXPECTED_TD_ARN="${{ steps.register.outputs.TASK_DEF_ARN }}"
+          ACTIVE_TD_ARN=$(aws ecs describe-services \
+            --cluster "${{ env.ECS_CLUSTER }}" \
+            --services "${{ env.ECS_SERVICE }}" \
+            --query 'services[0].taskDefinition' \
+            --output text)
+
+          if [ "$ACTIVE_TD_ARN" != "$EXPECTED_TD_ARN" ]; then
+            echo "ECS deployment did not become production. The deployment may have rolled back."
+            echo "Expected: $EXPECTED_TD_ARN"
+            echo "Active:   $ACTIVE_TD_ARN"
+            exit 1
+          fi
+
+          echo "Verified production task definition: $ACTIVE_TD_ARN"
 
       - name: Summary
         if: steps.gate.outputs.GO == 'true'
         run: |
-          if [ "${{ steps.wait.outputs.WAIT_FAILED }}" == "true" ]; then
-            echo "### ❌ ECS Deploy Failed" >> $GITHUB_STEP_SUMMARY
-            exit 1
-          else
-            echo "### ✅ ECS Deploy Completed (ARM64)" >> $GITHUB_STEP_SUMMARY
-            echo "- Cluster: \`${{ env.ECS_CLUSTER }}\`"
-            echo "- Service: \`${{ env.ECS_SERVICE }}\`"
-            echo "- TD: \`${{ steps.register.outputs.TASK_DEF_ARN }}\`"
-            echo "- Image: \`${PAYLOAD_IMAGE_URI}\`"
-          fi
+          echo "### ✅ ECS Deploy Completed (ARM64)" >> $GITHUB_STEP_SUMMARY
+          echo "- Cluster: \`${{ env.ECS_CLUSTER }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Service: \`${{ env.ECS_SERVICE }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- TD: \`${{ steps.register.outputs.TASK_DEF_ARN }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Image: \`${PAYLOAD_IMAGE_URI}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 📌 PR 개요

- ECS Blue/Green 배포가 롤백됐음에도 GitHub Actions가 성공으로 판단하던 문제를 수정합니다.

## 🔍 변경 사항

- 태스크 패밀리의 최신 개정이 아닌 현재 운영 중인 태스크 정의를 배포 기준으로 사용
- 롤백 시험용 태스크 정의가 다음 배포에 복사되는 문제 방지
- 배포 안정화 후 신규 태스크 정의가 실제 운영에 반영됐는지 검증
- 자동 롤백 발생 시 GitHub Actions를 실패로 처리
- GitHub Actions Summary 출력 보완

## 🧪 테스트 방법

1. develop 병합 후 main으로 PR을 생성합니다.
2. main 병합으로 ECR 및 ECS 배포 워크플로를 실행합니다.
3. 신규 태스크 정의가 생성되는지 확인합니다.
4. ECS 서비스의 운영 태스크 정의가 신규 개정으로 변경되는지 확인합니다.
5. CloudFront를 통한 종단 테스트를 진행합니다.

## ✅ 체크리스트

- [x] 현재 운영 태스크 정의를 배포 기준으로 사용
- [x] 롤백을 성공으로 오판하지 않도록 검증 추가
- [x] YAML 파싱 및 diff 검사 통과
- [x] 애플리케이션 코드 변경 없음
- [ ] 실제 ECS 자동 배포 성공 확인
- [ ] 종단 테스트 완료

## 📎 참고 이슈

Ref: #91